### PR TITLE
Change release name and remove `waitUntil`

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "${{env.CURRENT_VERSION}}"
-          name: "Release ${{env.CURRENT_VERSION}}"
+          name: "${{env.CURRENT_VERSION}}"
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,6 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
-              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
- The release name now contains only the version number (e.g., `0.1.0` instead of `Release 0.1.0`).
- In pom.xml, removed `<waitUntil>published</waitUntil>`.