### PR TITLE
Add `toTextByTags`, `toTextByTag` and `readFile` methods

### DIFF
--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/XmlUtils.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/XmlUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.core;
+
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+/**
+ * Utility class for XML parsing and manipulation.
+ */
+public class XmlUtils {
+
+  private static final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+  /**
+   * Parses the given XML string into a Document object.
+   *
+   * @param xml The XML string to be parsed.
+   * @return A Document object representing the XML structure.
+   */
+  public static Document parse(String xml) {
+    try {
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      return builder.parse(new InputSource(new StringReader(xml)));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/modules/watsonx-ai-core/src/test/java/com/ibm/watsonx/ai/core/AsyncHttpClientTest.java
+++ b/modules/watsonx-ai-core/src/test/java/com/ibm/watsonx/ai/core/AsyncHttpClientTest.java
@@ -70,7 +70,7 @@ public class AsyncHttpClientTest {
 
   @RegisterExtension
   WireMockExtension wireMock = WireMockExtension.newInstance()
-    .options(wireMockConfig().dynamicPort().dynamicHttpsPort())
+    .options(wireMockConfig().dynamicPort().dynamicHttpsPort().http2PlainDisabled(true))
     .build();
 
   static final Answer<CompletableFuture<HttpResponse<String>>> CHAIN_MOCK = invocation -> {
@@ -304,7 +304,7 @@ public class AsyncHttpClientTest {
   }
 
   @Test
-  void test_complete_requests_in_response_order_not_call_order() throws Exception {
+  void test_async_responses_returned_in_order_of_completion_not_submission() throws Exception {
 
     var url = "http://localhost:%s/my-path".formatted(wireMock.getPort());
 

--- a/modules/watsonx-ai-core/src/test/java/com/ibm/watsonx/ai/core/HttpUtilsTest.java
+++ b/modules/watsonx-ai-core/src/test/java/com/ibm/watsonx/ai/core/HttpUtilsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+// Assisted by watsonx Code Assistant
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.skyscreamer.jsonassert.JSONAssert;
+import com.ibm.watsonx.ai.core.exeception.model.WatsonxError;
+import com.ibm.watsonx.ai.core.exeception.model.WatsonxError.Error;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+public class HttpUtilsTest {
+
+  @Test
+  void test_extract_body_as_string_with_string() {
+    HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
+    when(mockHttpResponse.body()).thenReturn("test string body");
+    String result = HttpUtils.extractBodyAsString(mockHttpResponse).get();
+    assertEquals("test string body", result);
+  }
+
+  @Test
+  void test_extract_body_as_string_with_byte_array() {
+    HttpResponse<byte[]> mockHttpResponse = mock(HttpResponse.class);
+    byte[] bytes = "test byte array body".getBytes(StandardCharsets.UTF_8);
+    when(mockHttpResponse.body()).thenReturn(bytes);
+    String result = HttpUtils.extractBodyAsString(mockHttpResponse).get();
+    assertEquals("test byte array body", result);
+  }
+
+  @Test
+  void test_extract_body_as_string_with_input_stream() {
+    HttpResponse<InputStream> mockHttpResponse = mock(HttpResponse.class);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream("test input stream body".getBytes(StandardCharsets.UTF_8));
+    when(mockHttpResponse.body()).thenReturn(inputStream);
+    String result = HttpUtils.extractBodyAsString(mockHttpResponse).get();
+    assertEquals("test input stream body", result);
+  }
+
+  @Test
+  void test_extract_body_as_string_with_stream() {
+    HttpResponse<Stream<String>> mockHttpResponse = mock(HttpResponse.class);
+    Stream<String> stream = Stream.of("test", "stream", "body");
+    when(mockHttpResponse.body()).thenReturn(stream);
+    String result = HttpUtils.extractBodyAsString(mockHttpResponse).get();
+    assertEquals("test\nstream\nbody", result);
+  }
+
+  @Test
+  void test_extract_body_as_string_with_path(@TempDir Path tempDir) throws IOException {
+    Path tempFile = Files.createTempFile(tempDir, "prefix-", ".txt");
+    Files.write(tempFile, "test path body".getBytes(StandardCharsets.UTF_8));
+    HttpResponse<Path> mockHttpResponse = mock(HttpResponse.class);
+    when(mockHttpResponse.body()).thenReturn(tempFile);
+    String result = HttpUtils.extractBodyAsString(mockHttpResponse).get();
+    assertEquals("test path body", result);
+  }
+
+  @Test
+  void test_in_one_line_empty_headers() {
+    Map<String, List<String>> headers = Map.of();
+    String result = HttpUtils.inOneLine(headers);
+    assertEquals("", result);
+  }
+
+  @Test
+  void test_in_one_line_single_header() {
+    Map<String, List<String>> headers = Map.of("Test-Header", Arrays.asList("Value"));
+    String result = HttpUtils.inOneLine(headers);
+    assertEquals("[Test-Header: Value]", result);
+  }
+
+  @Test
+  void test_in_one_line_multiple_headers() {
+    LinkedHashMap<String, List<String>> headers = new LinkedHashMap<>();
+    headers.put("Test-Header-1", Arrays.asList("Value1"));
+    headers.put("Test-Header-2", Arrays.asList("Value2"));
+    String result = HttpUtils.inOneLine(headers);
+    assertEquals("[Test-Header-1: Value1], [Test-Header-2: Value2]", result);
+  }
+
+  @Test
+  void test_in_one_line_mask_authorization_header_value() {
+    Map<String, List<String>> headers = Map.of("Authorization", Arrays.asList("Bearer abc123def456"));
+    String result = HttpUtils.inOneLine(headers);
+    assertEquals("[Authorization: Bearer abc1...f456]", result);
+  }
+
+  @Test
+  void test_parse_error_body_json() {
+    WatsonxError watsonxError = new WatsonxError(400, "Internal Server Error", List.of(new Error("ERROR", "error", "error")));
+    String jsonBody = Json.toJson(watsonxError);
+    WatsonxError result = HttpUtils.parseErrorBody(jsonBody, "application/json");
+    JSONAssert.assertEquals(jsonBody, Json.toJson(result), true);
+  }
+
+  @Test
+  void test_parse_error_body_xml() {
+    String xmlBody = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <Error>
+          <Code>NoSuchBucket</Code>
+          <Message>The specified bucket does not exist.</Message>
+          <Resource>/my-bucket-name/test.pdf</Resource>
+          <RequestId>my-request-id</RequestId>
+          <httpStatusCode>404</httpStatusCode>
+      </Error>""";
+    Error error = new WatsonxError.Error("NoSuchBucket", "The specified bucket does not exist.", "/my-bucket-name/test.pdf");
+    WatsonxError expected = new WatsonxError(404, "my-request-id", List.of(error));
+    WatsonxError result = HttpUtils.parseErrorBody(xmlBody, "application/xml");
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testParseErrorBody_UnsupportedContentType() {
+    assertThrows(RuntimeException.class, () -> {
+      HttpUtils.parseErrorBody("test body", "text/plain");
+    });
+  }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionService.java
@@ -417,6 +417,23 @@ public class TextExtractionService extends WatsonxService {
     }
   }
 
+  /*
+   * Reads a file from the specified bucket.
+   *
+   * @param bucketName The name of the bucket.
+   * @param fileName The name of the file to read.
+   */
+  public String readFile(String bucketName, String fileName) {
+    try {
+      var encodedFileName = new URI(null, null, fileName, null).toASCIIString();
+      var uri = URI.create(cosUrl + "/%s/%s".formatted(bucketName, encodedFileName));
+      var httpRequest = HttpRequest.newBuilder(uri).GET().build();
+      return syncHttpClient.send(httpRequest, BodyHandlers.ofString()).body();
+    } catch (IOException | InterruptedException | URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Deletes a text extraction request.
    *
@@ -556,7 +573,7 @@ public class TextExtractionService extends WatsonxService {
       } else {
 
         var type = Type.fromValue(requestedOutputs.get(0));
-        outputFileName = FileUtils.addExtension(path, type);
+        outputFileName = TextExtractionUtils.addExtension(path, type);
       }
     }
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionUtils.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionUtils.java
@@ -8,9 +8,9 @@ import static java.util.Objects.requireNonNull;
 import com.ibm.watsonx.ai.textextraction.TextExtractionParameters.Type;
 
 /**
- * Utility class for file-related operations.
+ * Utility class for text extraction operations.
  */
-public class FileUtils {
+public class TextExtractionUtils {
 
   /**
    * Adds a file extension to a given file name.

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TextExtractionTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TextExtractionTest.java
@@ -69,7 +69,6 @@ import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.exeception.WatsonxException;
 import com.ibm.watsonx.ai.core.exeception.model.WatsonxError;
 import com.ibm.watsonx.ai.textextraction.CosReference;
-import com.ibm.watsonx.ai.textextraction.FileUtils;
 import com.ibm.watsonx.ai.textextraction.TextExtractionDeleteParameters;
 import com.ibm.watsonx.ai.textextraction.TextExtractionException;
 import com.ibm.watsonx.ai.textextraction.TextExtractionFetchParameters;
@@ -93,6 +92,7 @@ import com.ibm.watsonx.ai.textextraction.TextExtractionResponse.Error;
 import com.ibm.watsonx.ai.textextraction.TextExtractionResponse.ExtractionResult;
 import com.ibm.watsonx.ai.textextraction.TextExtractionResponse.Metadata;
 import com.ibm.watsonx.ai.textextraction.TextExtractionService;
+import com.ibm.watsonx.ai.textextraction.TextExtractionUtils;
 
 @SuppressWarnings("unchecked")
 @ExtendWith(MockitoExtension.class)
@@ -898,9 +898,9 @@ public class TextExtractionTest {
 
   @Test
   void test_file_utils() {
-    assertEquals("file.json", FileUtils.addExtension("file.json", Type.JSON));
-    assertEquals("file.html", FileUtils.addExtension("file.json", Type.HTML));
-    assertEquals("/", FileUtils.addExtension("/", Type.PAGE_IMAGES));
+    assertEquals("file.json", TextExtractionUtils.addExtension("file.json", Type.JSON));
+    assertEquals("file.html", TextExtractionUtils.addExtension("file.json", Type.HTML));
+    assertEquals("/", TextExtractionUtils.addExtension("/", Type.PAGE_IMAGES));
   }
 
   @Test


### PR DESCRIPTION
- Added `toTextByTag` and `toTextByTags` for quick tags extraction when using thinking models.
- Introduced `readFile` in TextExtractionService to fetch files from COS.
- Extracted common XML parsing into XmlUtils and other small utility classes.
- Polished code and improved test coverage.