### PR TITLE
Add the `X-Global-Transaction-Id` header

### DIFF
--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/AsyncHttpClient.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/AsyncHttpClient.java
@@ -72,8 +72,7 @@ public final class AsyncHttpClient extends BaseHttpClient {
      * @return a {@link CompletableFuture} of the HTTP response
      */
     public <T> CompletableFuture<HttpResponse<T>> send(HttpRequest request, BodyHandler<T> handler, Executor executor) {
-        return new InterceptorChain(delegate, interceptors).proceed(request, handler,
-            requireNonNullElse(executor, executor()));
+        return new InterceptorChain(delegate, interceptors).proceed(request, handler, requireNonNullElse(executor, executor()));
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxParameters.java
@@ -10,10 +10,12 @@ package com.ibm.watsonx.ai;
 public abstract class WatsonxParameters {
     protected final String projectId;
     protected final String spaceId;
+    protected final String transactionId;
 
     public WatsonxParameters(Builder<?> builder) {
         projectId = builder.projectId;
         spaceId = builder.spaceId;
+        transactionId = builder.transactionId;
     }
 
     /**
@@ -35,6 +37,15 @@ public abstract class WatsonxParameters {
     }
 
     /**
+     * Returns the transaction id.
+     *
+     * @return transaction id value
+     */
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    /**
      * Abstract builder class for constructing {@link WatsonxParameters} instances.
      *
      * @param <T> the type of the concrete builder subclass
@@ -43,6 +54,7 @@ public abstract class WatsonxParameters {
     public static abstract class Builder<T extends Builder<T>> {
         private String projectId;
         private String spaceId;
+        private String transactionId;
 
         /**
          * Sets the project id.
@@ -61,6 +73,16 @@ public abstract class WatsonxParameters {
          */
         public T spaceId(String spaceId) {
             this.spaceId = spaceId;
+            return (T) this;
+        }
+
+        /**
+         * Sets the transaction id for request tracking.
+         *
+         * @param transactionId the transaction id.
+         */
+        public T transactionId(String transactionId) {
+            this.transactionId = transactionId;
             return (T) this;
         }
     }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
@@ -57,7 +57,6 @@ public abstract class WatsonxService {
     protected final SyncHttpClient syncHttpClient;
     protected final HttpClient httpClient;
     protected final AsyncHttpClient asyncHttpClient;
-    protected final AuthenticationProvider authenticationProvider;
 
     protected WatsonxService(Builder<?> builder) {
         url = requireNonNull(builder.url, "The url must be provided");
@@ -76,12 +75,9 @@ public abstract class WatsonxService {
         asyncHttpClientBuilder.interceptor(retryInterceptor);
 
         if (nonNull(builder.authenticationProvider)) {
-            authenticationProvider = builder.authenticationProvider;
-            var bearerInterceptor = new BearerInterceptor(authenticationProvider);
+            var bearerInterceptor = new BearerInterceptor(builder.authenticationProvider);
             syncHttpClientBuilder.interceptor(bearerInterceptor);
             asyncHttpClientBuilder.interceptor(bearerInterceptor);
-        } else {
-            authenticationProvider = null;
         }
 
         if (logRequests || logResponses) {
@@ -189,6 +185,15 @@ public abstract class WatsonxService {
         public T authenticationProvider(AuthenticationProvider authenticationProvider) {
             this.authenticationProvider = authenticationProvider;
             return (T) this;
+        }
+
+        /**
+         * Returns the authentication provider.
+         *
+         * @return the configured {@link AuthenticationProvider}, or {@code null} if none has been set.
+         */
+        public AuthenticationProvider getAuthenticationProvider() {
+            return authenticationProvider;
         }
     }
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
@@ -20,7 +20,6 @@ import com.ibm.watsonx.ai.core.http.interceptors.LoggerInterceptor;
 import com.ibm.watsonx.ai.core.http.interceptors.RetryInterceptor;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
 import com.ibm.watsonx.ai.embedding.EmbeddingService;
-import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
 import com.ibm.watsonx.ai.rerank.RerankService;
 import com.ibm.watsonx.ai.textextraction.TextExtractionService;
@@ -49,6 +48,7 @@ public abstract class WatsonxService {
     public static final String ML_API_PATH = "/ml/v1";
     public static final String ML_API_TEXT_PATH = ML_API_PATH.concat("/text");
     public static final String API_VERSION = "2025-04-23";
+    public static final String TRANSACTION_ID_HEADER = "X-Global-Transaction-Id";
 
     protected final URI url;
     protected final String version;
@@ -261,17 +261,6 @@ public abstract class WatsonxService {
                     .build()
             );
         }
-
-        /**
-         * Retrieves model details.
-         *
-         * @return Details of the the model.
-         */
-        public FoundationModel getModelDetails() {
-            return foundationModelService.getModelDetails(modelId)
-                .orElseThrow(() -> new RuntimeException("The model with id \"%s\" doesn't exist".formatted(modelId)));
-        }
-
 
         @SuppressWarnings("unchecked")
         protected static abstract class Builder<T extends Builder<T>> extends ProjectService.Builder<T> {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatService.java
@@ -52,7 +52,7 @@ public final class ChatService extends ModelService implements ChatProvider {
 
     protected ChatService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/embedding/EmbeddingService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/embedding/EmbeddingService.java
@@ -9,6 +9,7 @@ import static com.ibm.watsonx.ai.core.Json.toJson;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.Optional.ofNullable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -87,12 +88,14 @@ public final class EmbeddingService extends ModelService {
         String modelId = this.modelId;
         String projectId = this.projectId;
         String spaceId = this.spaceId;
+        String transactionId = null;
         Parameters requestParameters = null;
 
         if (nonNull(parameters)) {
             modelId = requireNonNullElse(parameters.getModelId(), this.modelId);
-            projectId = nonNull(parameters.getProjectId()) ? parameters.getProjectId() : this.projectId;
-            spaceId = nonNull(parameters.getSpaceId()) ? parameters.getSpaceId() : this.spaceId;
+            projectId = ofNullable(parameters.getProjectId()).orElse(this.projectId);
+            spaceId = ofNullable(parameters.getSpaceId()).orElse(this.spaceId);
+            transactionId = parameters.getTransactionId();
             requestParameters = parameters.toEmbeddingRequestParameters();
         }
 
@@ -113,12 +116,14 @@ public final class EmbeddingService extends ModelService {
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .POST(BodyPublishers.ofString(toJson(embeddingRequest)))
-                .timeout(timeout)
-                .build();
+                .timeout(timeout);
+
+            if (nonNull(transactionId))
+                httpRequest.header(TRANSACTION_ID_HEADER, transactionId);
 
             try {
 
-                var httpReponse = syncHttpClient.send(httpRequest, BodyHandlers.ofString());
+                var httpReponse = syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
                 var response = fromJson(httpReponse.body(), EmbeddingResponse.class);
                 results.addAll(response.results());
                 inputTokenCount += response.inputTokenCount();

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/embedding/EmbeddingService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/embedding/EmbeddingService.java
@@ -50,7 +50,7 @@ public final class EmbeddingService extends ModelService {
 
     protected EmbeddingService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/foundationmodel/FoundationModel.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/foundationmodel/FoundationModel.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.watsonx.ai.foundationmodel;
 
+import static java.util.Optional.ofNullable;
 import java.util.List;
 import java.util.Map;
 
@@ -35,11 +36,11 @@ public record FoundationModel(
     List<DeploymentParameter> deploymentParameters) {
 
     public Integer maxSequenceLength() {
-        return modelLimits.maxSequenceLength();
+        return ofNullable(modelLimits).map(m -> m.maxSequenceLength()).orElse(null);
     }
 
     public Integer maxOutputTokens() {
-        return modelLimits.maxOutputTokens();
+        return ofNullable(modelLimits).map(m -> m.maxOutputTokens()).orElse(null);
     }
 
     public record Function(String id) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/foundationmodel/FoundationModelParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/foundationmodel/FoundationModelParameters.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.foundationmodel;
+
+import static java.util.Objects.nonNull;
+import com.ibm.watsonx.ai.foundationmodel.filter.Filter;
+
+/**
+ * Represents a set of parameters used to control the behavior of a foundation models specs.
+ * <p>
+ * Instances of this class are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * FoundationModelParameters.builder()
+ *     .filter(Filter.of(modelId("ibm/granite-13b-instruct-v2")))
+ *     .techPreview(true)
+ *     .build();
+ * }</pre>
+ *
+ */
+public class FoundationModelParameters {
+    private final Integer start;
+    private final Integer limit;
+    private final Filter filter;
+    private final String transactionId;
+    private final Boolean techPreview;
+
+    protected FoundationModelParameters(Builder builder) {
+        this.start = builder.start;
+        this.limit = builder.limit;
+        this.filter = builder.filter;
+        this.transactionId = builder.transactionId;
+        this.techPreview = builder.techPreview;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public String getFilter() {
+        return nonNull(filter) ? filter.toString() : null;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public Boolean getTechPreview() {
+        return techPreview;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * FoundationModelParameters.builder()
+     *     .filter(Filter.of(modelId("ibm/granite-13b-instruct-v2")))
+     *     .techPreview(true)
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link FoundationModelParameters} instances.
+     */
+    public static class Builder {
+        private Integer start;
+        private Integer limit;
+        private Filter filter;
+        private String transactionId;
+        private Boolean techPreview;
+
+        /**
+         * Sets the pagination start token.
+         *
+         * @param start the pagination start token.
+         */
+        public Builder start(Integer start) {
+            this.start = start;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of resources to return.
+         *
+         * @param limit the maximum number of resources to return.
+         */
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        /**
+         * Sets the filters to apply.
+         *
+         * @param filter the filter object.
+         */
+        public Builder filter(Filter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        /**
+         * Sets the transaction id for request tracking.
+         *
+         * @param transactionId the transaction id.
+         */
+        public Builder transactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        /**
+         * Sets whether Tech Preview models should be included in the response.
+         *
+         * @param techPreview {@code true} to include Tech Preview models, {@code false} otherwise.
+         */
+        public Builder techPreview(Boolean techPreview) {
+            this.techPreview = techPreview;
+            return this;
+        }
+
+        /**
+         * Builds a {@link FoundationModelParameters} instance.
+         *
+         * @return a new instance of {@link FoundationModelParameters}
+         */
+        public FoundationModelParameters build() {
+            return new FoundationModelParameters(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/rerank/RerankService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/rerank/RerankService.java
@@ -51,7 +51,7 @@ public final class RerankService extends ModelService {
 
     protected RerankService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/rerank/RerankService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/rerank/RerankService.java
@@ -9,6 +9,7 @@ import static com.ibm.watsonx.ai.core.Json.toJson;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.Optional.ofNullable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -81,12 +82,14 @@ public final class RerankService extends ModelService {
         String modelId = this.modelId;
         String projectId = this.projectId;
         String spaceId = this.spaceId;
+        String transactionId = null;
         Parameters requestParameters = null;
 
         if (nonNull(parameters)) {
             modelId = requireNonNullElse(parameters.getModelId(), this.modelId);
-            projectId = nonNull(parameters.getProjectId()) ? parameters.getProjectId() : this.projectId;
-            spaceId = nonNull(parameters.getSpaceId()) ? parameters.getSpaceId() : this.spaceId;
+            projectId = ofNullable(parameters.getProjectId()).orElse(this.projectId);
+            spaceId = ofNullable(parameters.getSpaceId()).orElse(this.spaceId);
+            transactionId = parameters.getTransactionId();
             requestParameters = parameters.toRerankRequestParameters();
         }
 
@@ -103,12 +106,14 @@ public final class RerankService extends ModelService {
             .newBuilder(URI.create(url.toString() + "%s/rerank?version=%s".formatted(ML_API_TEXT_PATH, version)))
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .POST(BodyPublishers.ofString(toJson(rerankRequest)))
-            .build();
+            .POST(BodyPublishers.ofString(toJson(rerankRequest)));
+
+        if (nonNull(transactionId))
+            httpRequest.header(TRANSACTION_ID_HEADER, transactionId);
 
         try {
 
-            var httpReponse = syncHttpClient.send(httpRequest, BodyHandlers.ofString());
+            var httpReponse = syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
             return fromJson(httpReponse.body(), RerankResponse.class);
 
         } catch (IOException | InterruptedException e) {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionParameters.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import com.ibm.watsonx.ai.WatsonxParameters;
 import com.ibm.watsonx.ai.textextraction.TextExtractionRequest.Parameters;
 import com.ibm.watsonx.ai.textextraction.TextExtractionRequest.SemanticConfig;
@@ -461,12 +462,10 @@ public final class TextExtractionParameters extends WatsonxParameters {
         }
 
         public static Type fromValue(String value) {
-            for (Type type : Type.values()) {
-                if (type.value.equalsIgnoreCase(value)) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException("Unknown Type value: " + value);
+            return Stream.of(Type.values())
+                .filter(status -> status.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown Type value: " + value));
         }
     }
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionResponse.java
@@ -6,6 +6,7 @@ package com.ibm.watsonx.ai.textextraction;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import com.ibm.watsonx.ai.textextraction.TextExtractionRequest.DataReference;
 import com.ibm.watsonx.ai.textextraction.TextExtractionRequest.Parameters;
 
@@ -81,12 +82,10 @@ public record TextExtractionResponse(Metadata metadata, Entity entity) {
         }
 
         public static Status fromValue(String value) {
-            for (Status status : Status.values()) {
-                if (status.value.equalsIgnoreCase(value)) {
-                    return status;
-                }
-            }
-            throw new IllegalArgumentException("Unknown Type value: " + value);
+            return Stream.of(Status.values())
+                .filter(status -> status.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown Type value: " + value));
         }
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionService.java
@@ -71,7 +71,7 @@ public final class TextExtractionService extends ProjectService {
 
     protected TextExtractionService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
         var tmpUrl = requireNonNull(builder.cosUrl, "cosUrl value cannot be null");
         cosUrl = tmpUrl.endsWith("/") ? tmpUrl.substring(0, tmpUrl.length() - 1) : tmpUrl;
         documentReference = requireNonNull(builder.documentReference, "documentReference value cannot be null");

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationParameters.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.watsonx.ai.textgeneration;
 
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNullElse;
 import java.time.Duration;
 import java.util.List;
@@ -142,6 +143,37 @@ public final class TextGenerationParameters extends WatsonxModelParameters {
 
     public void setPromptVariables(Map<String, String> promptVariables) {
         this.promptVariables = promptVariables;
+    }
+
+    /**
+     * Creates a new {@link Builder} instance initialized with all the current {@link TextGenerationParameters} values, except for {@code modelId},
+     * {@code projectId}, {@code spaceId}, and {@code transactionId}.
+     *
+     * @return a {@link TextGenerationParameters} pre-populated with the current object's values, excluding any fields that must be omitted.
+     */
+    public TextGenerationParameters toSanitized() {
+        var builder = new Builder()
+            .decodingMethod(decodingMethod)
+            .includeStopSequence(includeStopSequence)
+            .maxNewTokens(maxNewTokens)
+            .minNewTokens(minNewTokens)
+            .promptVariables(promptVariables)
+            .randomSeed(randomSeed)
+            .repetitionPenalty(repetitionPenalty)
+            .returnOptions(returnOptions)
+            .stopSequences(stopSequences)
+            .temperature(temperature)
+            .topK(topK)
+            .topP(topP)
+            .truncateInputTokens(truncateInputTokens);
+
+        if (nonNull(lengthPenalty))
+            builder.lengthPenalty(lengthPenalty.decayFactor(), lengthPenalty.startIndex());
+
+        if (nonNull(timeLimit))
+            builder.timeLimit(Duration.ofMillis(timeLimit));
+
+        return builder.build();
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationService.java
@@ -10,6 +10,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.Optional.ofNullable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -68,13 +69,13 @@ public final class TextGenerationService extends ModelService implements TextGen
         }
 
         var modelId = requireNonNullElse(parameters.getModelId(), this.modelId);
-        var projectId = nonNull(parameters.getProjectId()) ? parameters.getProjectId() : this.projectId;
-        var spaceId = nonNull(parameters.getSpaceId()) ? parameters.getSpaceId() : this.spaceId;
+        var projectId = ofNullable(parameters.getProjectId()).orElse(this.projectId);
+        var spaceId = ofNullable(parameters.getSpaceId()).orElse(this.spaceId);
         var timeout = requireNonNullElse(parameters.getTimeLimit(), this.timeout.toMillis());
         parameters.setTimeLimit(timeout);
 
         var textGenerationRequest =
-            new TextGenerationRequest(modelId, spaceId, projectId, input, parameters, moderation);
+            new TextGenerationRequest(modelId, spaceId, projectId, input, parameters.toSanitized(), moderation);
 
         var httpRequest =
             HttpRequest
@@ -82,12 +83,14 @@ public final class TextGenerationService extends ModelService implements TextGen
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .timeout(Duration.ofMillis(timeout))
-                .POST(BodyPublishers.ofString(toJson(textGenerationRequest)))
-                .build();
+                .POST(BodyPublishers.ofString(toJson(textGenerationRequest)));
+
+        if (nonNull(parameters.getTransactionId()))
+            httpRequest.header(TRANSACTION_ID_HEADER, parameters.getTransactionId());
 
         try {
 
-            var httpReponse = syncHttpClient.send(httpRequest, BodyHandlers.ofString());
+            var httpReponse = syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
             return fromJson(httpReponse.body(), TextGenerationResponse.class);
 
         } catch (IOException | InterruptedException e) {
@@ -107,24 +110,26 @@ public final class TextGenerationService extends ModelService implements TextGen
         }
 
         var modelId = requireNonNullElse(parameters.getModelId(), this.modelId);
-        var projectId = nonNull(parameters.getProjectId()) ? parameters.getProjectId() : this.projectId;
-        var spaceId = nonNull(parameters.getSpaceId()) ? parameters.getSpaceId() : this.spaceId;
+        var projectId = ofNullable(parameters.getProjectId()).orElse(this.projectId);
+        var spaceId = ofNullable(parameters.getSpaceId()).orElse(this.spaceId);
         var timeout = requireNonNullElse(parameters.getTimeLimit(), this.timeout.toMillis());
         parameters.setTimeLimit(timeout);
 
         var textGenerationRequest =
-            new TextGenerationRequest(modelId, spaceId, projectId, input, parameters, null);
+            new TextGenerationRequest(modelId, spaceId, projectId, input, parameters.toSanitized(), null);
 
         var httpRequest = HttpRequest.newBuilder(URI.create(url.toString() + "%s/generation_stream?version=%s".formatted(ML_API_TEXT_PATH, version)))
             .header("Content-Type", "application/json")
             .header("Accept", "text/event-stream")
             .timeout(Duration.ofMillis(timeout))
-            .POST(BodyPublishers.ofString(toJson(textGenerationRequest)))
-            .build();
+            .POST(BodyPublishers.ofString(toJson(textGenerationRequest)));
+
+        if (nonNull(parameters.getTransactionId()))
+            httpRequest.header(TRANSACTION_ID_HEADER, parameters.getTransactionId());
 
         var subscriber = subscriber(handler);
         return asyncHttpClient
-            .send(httpRequest,
+            .send(httpRequest.build(),
                 responseInfo -> logResponses
                     ? BodySubscribers.fromLineSubscriber(new SseEventLogger(subscriber, responseInfo.statusCode(), responseInfo.headers()))
                     : BodySubscribers.fromLineSubscriber(subscriber)

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationService.java
@@ -51,7 +51,7 @@ public final class TextGenerationService extends ModelService implements TextGen
 
     protected TextGenerationService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     @Override

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesService.java
@@ -55,7 +55,7 @@ public final class TimeSeriesService extends ModelService implements TimeSeriesP
 
     protected TimeSeriesService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     @Override

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tokenization/TokenizationService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tokenization/TokenizationService.java
@@ -9,6 +9,7 @@ import static com.ibm.watsonx.ai.core.Json.toJson;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.Optional.ofNullable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -69,12 +70,14 @@ public final class TokenizationService extends ModelService {
         String modelId = this.modelId;
         String projectId = this.projectId;
         String spaceId = this.spaceId;
+        String transactionId = null;
         Parameters requestParameters = null;
 
         if (nonNull(parameters)) {
             modelId = requireNonNullElse(parameters.getModelId(), this.modelId);
-            projectId = nonNull(parameters.getProjectId()) ? parameters.getProjectId() : this.projectId;
-            spaceId = nonNull(parameters.getSpaceId()) ? parameters.getSpaceId() : this.spaceId;
+            projectId = ofNullable(parameters.getProjectId()).orElse(this.projectId);
+            spaceId = ofNullable(parameters.getSpaceId()).orElse(this.spaceId);
+            transactionId = parameters.getTransactionId();
             requestParameters = parameters.toTokenizationRequestParameters();
         }
 
@@ -85,12 +88,14 @@ public final class TokenizationService extends ModelService {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .POST(BodyPublishers.ofString(toJson(tokenizationRequest)))
-            .timeout(timeout)
-            .build();
+            .timeout(timeout);
+
+        if (nonNull(transactionId))
+            httpRequest.header(TRANSACTION_ID_HEADER, transactionId);
 
         try {
 
-            var httpReponse = syncHttpClient.send(httpRequest, BodyHandlers.ofString());
+            var httpReponse = syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
             return fromJson(httpReponse.body(), TokenizationResponse.class);
 
         } catch (IOException | InterruptedException e) {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tokenization/TokenizationService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tokenization/TokenizationService.java
@@ -24,14 +24,14 @@ import com.ibm.watsonx.ai.tokenization.TokenizationRequest.Parameters;
  * <b>Example usage:</b>
  *
  * <pre>{@code
- * TokenizationService rerankService = TokenizationService.builder()
+ * TokenizationService tokenizationService = TokenizationService.builder()
  *     .url("https://...") // or use CloudRegion
  *     .authenticationProvider(authProvider)
  *     .projectId("my-project-id")
  *     .modelId("ibm/granite-3-8b-instruct")
  *     .build();
  *
- * TokenizationResponse response = TokenizationService.tokenize("Tell me a joke");
+ * TokenizationResponse response = tokenizationService.tokenize("Tell me a joke");
  * }</pre>
  *
  * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-tokenization" target="_blank"> official documentation</a>.
@@ -42,7 +42,7 @@ public final class TokenizationService extends ModelService {
 
     protected TokenizationService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     /**
@@ -104,14 +104,14 @@ public final class TokenizationService extends ModelService {
      * <b>Example usage:</b>
      *
      * <pre>{@code
-     * TokenizationService rerankService = TokenizationService.builder()
+     * TokenizationService tokenizationService = TokenizationService.builder()
      *     .url("https://...") // or use CloudRegion
      *     .authenticationProvider(authProvider)
      *     .projectId("my-project-id")
      *     .modelId("ibm/granite-3-8b-instruct")
      *     .build();
      *
-     * TokenizationResponse response = TokenizationService.tokenize("Tell me a joke");
+     * TokenizationResponse response = tokenizationService.tokenize("Tell me a joke");
      * }</pre>
      *
      * @see AuthenticationProvider

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tool/ToolParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tool/ToolParameters.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.tool;
+
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelParameters;
+
+/**
+ * Represents a set of parameters used to control the behavior of a Tool APIs.
+ * <p>
+ * Instances of this class are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ToolParameters.builder()
+ *     .transactionId("transaction-id")
+ *     .build();
+ * }</pre>
+ *
+ */
+public class ToolParameters {
+    private final String transactionId;
+
+    protected ToolParameters(Builder builder) {
+        this.transactionId = builder.transactionId;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ToolParameters.builder()
+     *     .transactionId("transaction-id")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link FoundationModelParameters} instances.
+     */
+    public static class Builder {
+        private String transactionId;
+
+        /**
+         * Sets the transaction id for request tracking.
+         *
+         * @param transactionId the transaction id.
+         */
+        public Builder transactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        /**
+         * Builds a {@link ToolParameters} instance.
+         *
+         * @return a new instance of {@link ToolParameters}
+         */
+        public ToolParameters build() {
+            return new ToolParameters(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tool/ToolService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tool/ToolService.java
@@ -62,7 +62,7 @@ public final class ToolService extends WatsonxService {
 
     public ToolService(Builder builder) {
         super(builder);
-        requireNonNull(super.authenticationProvider, "authenticationProvider cannot be null");
+        requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
     }
 
     /**

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/RerankServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/RerankServiceTest.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.watsonx.ai;
 
+import static com.ibm.watsonx.ai.WatsonxService.TRANSACTION_ID_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -181,6 +182,7 @@ public class RerankServiceTest {
             .projectId("my-new-project-id")
             .spaceId("my-new-space-id")
             .modelId("my-new-model-id")
+            .transactionId("my-transaction-id")
             .query(true)
             .topN(2)
             .inputs(true)
@@ -203,6 +205,7 @@ public class RerankServiceTest {
 
         JSONAssert.assertEquals(REQUEST, Utils.bodyPublisherToString(httpRequestCaptor), true);
         JSONAssert.assertEquals(RESPONSE, Json.toJson(response), true);
+        assertEquals(httpRequestCaptor.getValue().headers().firstValue(TRANSACTION_ID_HEADER).orElse(null), "my-transaction-id");
     }
 
     @Test

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TimeSeriesServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TimeSeriesServiceTest.java
@@ -9,6 +9,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.ibm.watsonx.ai.WatsonxService.TRANSACTION_ID_HEADER;
 import static com.ibm.watsonx.ai.core.Json.fromJson;
 import static com.ibm.watsonx.ai.core.Json.toJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -231,6 +232,7 @@ public class TimeSeriesServiceTest {
             .withHeader("Authorization", equalTo("Bearer my-super-token"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("Accept", equalTo("application/json"))
+            .withHeader(TRANSACTION_ID_HEADER, equalTo("my-transaction-id"))
             .withRequestBody(equalToJson(BODY))
             .willReturn(aResponse()
                 .withStatus(200)
@@ -241,6 +243,7 @@ public class TimeSeriesServiceTest {
             .projectId("my-project-id")
             .spaceId("my-space-id")
             .predictionLength(512)
+            .transactionId("my-transaction-id")
             .build();
 
         var result = tsService.forecast(inputSchema, data, parameters);

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TokenizationServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TokenizationServiceTest.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.watsonx.ai;
 
+import static com.ibm.watsonx.ai.WatsonxService.TRANSACTION_ID_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -135,6 +136,7 @@ public class TokenizationServiceTest {
 
         var parameters = TokenizationParameters.builder()
             .returnTokens(true)
+            .transactionId("my-transaction-id")
             .build();
 
         assertEquals(true, parameters.getReturnTokens());
@@ -146,6 +148,7 @@ public class TokenizationServiceTest {
 
         JSONAssert.assertEquals(REQUEST, Utils.bodyPublisherToString(httpRequestCaptor), true);
         JSONAssert.assertEquals(RESPONSE, Json.toJson(response), true);
+        assertEquals(httpRequestCaptor.getValue().headers().firstValue(TRANSACTION_ID_HEADER).orElse(null), "my-transaction-id");
     }
 
     @Test

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/ToolServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/ToolServiceTest.java
@@ -4,10 +4,12 @@
  */
 package com.ibm.watsonx.ai;
 
+import static com.ibm.watsonx.ai.WatsonxService.TRANSACTION_ID_HEADER;
 import static com.ibm.watsonx.ai.core.Json.fromJson;
 import static com.ibm.watsonx.ai.core.Json.toJson;
 import static com.ibm.watsonx.ai.utils.Utils.bodyPublisherToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
+import com.ibm.watsonx.ai.tool.ToolParameters;
 import com.ibm.watsonx.ai.tool.ToolRequest;
 import com.ibm.watsonx.ai.tool.ToolService;
 import com.ibm.watsonx.ai.tool.builtin.GoogleSearchTool;
@@ -107,6 +110,10 @@ public class ToolServiceTest {
             URI.create(CloudRegion.DALLAS.getWxEndpoint().concat("/v1-beta/utility_agent_tools")),
             httpRequest.getValue().uri()
         );
+
+        utilityTools = toolService.getAll(ToolParameters.builder().transactionId("my-transaction-id").build());
+        assertNotNull(utilityTools);
+        assertEquals(httpRequest.getValue().headers().firstValue(TRANSACTION_ID_HEADER).orElse(null), "my-transaction-id");
     }
 
     @Test
@@ -150,6 +157,10 @@ public class ToolServiceTest {
             URI.create(CloudRegion.DALLAS.getWxEndpoint().concat("/v1-beta/utility_agent_tools/GoogleSearch")),
             httpRequest.getValue().uri()
         );
+
+        utilityTools = toolService.getByName("GoogleSearch", ToolParameters.builder().transactionId("my-transaction-id").build());
+        assertNotNull(utilityTools);
+        assertEquals(httpRequest.getValue().headers().firstValue(TRANSACTION_ID_HEADER).orElse(null), "my-transaction-id");
     }
 
     @Test
@@ -178,6 +189,10 @@ public class ToolServiceTest {
             httpRequest.getValue().uri()
         );
         JSONAssert.assertEquals(toJson(body), bodyPublisherToString(httpRequest), true);
+
+        result = toolService.run(body, ToolParameters.builder().transactionId("my-transaction-id").build());
+        assertNotNull(result);
+        assertEquals(httpRequest.getValue().headers().firstValue(TRANSACTION_ID_HEADER).orElse(null), "my-transaction-id");
 
         body = ToolRequest.unstructuredInput("GoogleSearch", "test", Map.of("test", "test"));
         toolService.run(body);

--- a/samples/chatbot-streaming/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot-streaming/src/main/java/com/ibm/chatbot/AiService.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.chatbot;
 
+import static com.ibm.watsonx.ai.foundationmodel.filter.Filter.Expression.modelId;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -21,11 +22,15 @@ import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
+import com.ibm.watsonx.ai.foundationmodel.filter.Filter;
 
 public class AiService {
 
     private static final Config config = ConfigProvider.getConfig();
+    private static final String MODEL_ID = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8";
     private final ChatService chatService;
+    private final FoundationModelService foundationModelService;
     private final ChatMemory memory;
 
     public AiService() {
@@ -43,8 +48,14 @@ public class AiService {
             .authenticationProvider(authProvider)
             .projectId(projectId)
             .timeout(Duration.ofSeconds(60))
-            .modelId("meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
+            .modelId(MODEL_ID)
             .url(url)
+            .build();
+
+        foundationModelService = FoundationModelService.builder()
+            .authenticationProvider(authProvider)
+            .url(url)
+            .timeout(Duration.ofSeconds(60))
             .build();
 
         memory = new ChatMemory();
@@ -78,6 +89,6 @@ public class AiService {
     }
 
     public FoundationModel getModel() {
-        return chatService.getModelDetails();
+        return foundationModelService.getModels(Filter.of(modelId(MODEL_ID))).resources().get(0);
     }
 }

--- a/samples/chatbot-tools/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot-tools/src/main/java/com/ibm/chatbot/AiService.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.chatbot;
 
+import static com.ibm.watsonx.ai.foundationmodel.filter.Filter.Expression.modelId;
 import static java.util.Objects.nonNull;
 import java.net.URI;
 import java.time.Duration;
@@ -26,6 +27,8 @@ import com.ibm.watsonx.ai.core.Json;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
+import com.ibm.watsonx.ai.foundationmodel.filter.Filter;
 
 public class AiService {
 
@@ -44,7 +47,9 @@ public class AiService {
             .required("emails", "subject", "body")
     );
 
+    private static final String MODEL_ID = "mistralai/mistral-small-3-1-24b-instruct-2503";
     private final ChatService chatService;
+    private final FoundationModelService foundationModelService;
     private final ChatMemory memory;
 
     public AiService() {
@@ -61,8 +66,14 @@ public class AiService {
             .authenticationProvider(authProvider)
             .projectId(projectId)
             .timeout(Duration.ofSeconds(60))
-            .modelId("mistralai/mistral-small-3-1-24b-instruct-2503")
+            .modelId(MODEL_ID)
             .url(url)
+            .build();
+
+        foundationModelService = FoundationModelService.builder()
+            .authenticationProvider(authProvider)
+            .url(url)
+            .timeout(Duration.ofSeconds(60))
             .build();
 
         memory = new ChatMemory();
@@ -102,6 +113,6 @@ public class AiService {
     }
 
     public FoundationModel getModel() {
-        return chatService.getModelDetails();
+        return foundationModelService.getModels(Filter.of(modelId(MODEL_ID))).resources().get(0);
     }
 }

--- a/samples/chatbot/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot/src/main/java/com/ibm/chatbot/AiService.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.chatbot;
 
+import static com.ibm.watsonx.ai.foundationmodel.filter.Filter.Expression.modelId;
 import java.net.URI;
 import java.time.Duration;
 import org.eclipse.microprofile.config.Config;
@@ -16,11 +17,15 @@ import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
+import com.ibm.watsonx.ai.foundationmodel.filter.Filter;
 
 public class AiService {
 
     private static final Config config = ConfigProvider.getConfig();
+    private static final String MODEL_ID = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8";
     private final ChatService chatService;
+    private final FoundationModelService foundationModelService;
     private final ChatMemory memory;
 
     public AiService() {
@@ -38,8 +43,14 @@ public class AiService {
             .authenticationProvider(authProvider)
             .projectId(projectId)
             .timeout(Duration.ofSeconds(60))
-            .modelId("meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
+            .modelId(MODEL_ID)
             .url(url)
+            .build();
+
+        foundationModelService = FoundationModelService.builder()
+            .authenticationProvider(authProvider)
+            .url(url)
+            .timeout(Duration.ofSeconds(60))
             .build();
 
         memory = new ChatMemory();
@@ -59,6 +70,6 @@ public class AiService {
     }
 
     public FoundationModel getModel() {
-        return chatService.getModelDetails();
+        return foundationModelService.getModels(Filter.of(modelId(MODEL_ID))).resources().get(0);
     }
 }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.ibm.watsonx</groupId>
       <artifactId>watsonx-ai</artifactId>
-      <version>0.5.0</version>
+      <version>999-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The `transactionId` parameter has been added to all services. If this value is mapped, it will be used in the `X-Global-Transaction-Id` header.

[Documentation](https://cloud.ibm.com/apidocs/watsonx-ai#additional-headers)