### PR TITLE
Add new handlers to the `ChatHandler` interface

### DIFF
--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatHandler.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatHandler.java
@@ -5,6 +5,8 @@
 package com.ibm.watsonx.ai.chat;
 
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
+import com.ibm.watsonx.ai.chat.model.StreamingToolFetcher.PartialToolCall;
+import com.ibm.watsonx.ai.chat.model.ToolCall;
 
 /**
  * Callback interface used to handle streaming chat responses.
@@ -23,7 +25,7 @@ public interface ChatHandler {
     /**
      * Called once the full chat response has been received and the stream is complete. This marks the end of the response sequence.
      *
-     * @param completeResponse the full assembled chat response
+     * @param completeResponse the full chat response
      */
     void onCompleteResponse(ChatResponse completeResponse);
 
@@ -33,4 +35,24 @@ public interface ChatHandler {
      * @param error the exception that was thrown
      */
     void onError(Throwable error);
+
+    /**
+     * Called whenever a partial tool call is detected during the chat streaming process. This method may be invoked multiple times if the model
+     * streams tool call arguments or metadata in chunks.
+     *
+     * @param partialToolCall the partial chunk of the tool call received
+     */
+    default void onPartialToolCall(PartialToolCall partialToolCall) {
+        // Invoked whenever a partial tool call is detected during the streaming process
+    }
+
+    /**
+     * Called once a tool call has been fully received.
+     *
+     * @param completeToolCall the fully constructed tool call
+     */
+    default void onCompleteToolCall(ToolCall completeToolCall) {
+        // Allows triggering actions as soon as the complete tool call is available, without necessarily waiting for the full assistant response to
+        // finish streaming.
+    }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
@@ -254,6 +254,12 @@ public interface ChatProvider {
                             // First occurrence of the object, create it.
                             toolFetcher = new StreamingToolFetcher(index);
                             tools.add(toolFetcher);
+
+                            if (index - 1 >= 0) {
+                                var tool = tools.get(index - 1).build();
+                                handler.onCompleteToolCall(tool);
+                            }
+
                         } else {
                             // Incomplete version is present, complete it.
                             toolFetcher = tools.get(index);
@@ -265,6 +271,8 @@ public interface ChatProvider {
                             toolFetcher.setName(deltaTool.function().name());
                             toolFetcher.appendArguments(deltaTool.function().arguments());
                         }
+
+                        handler.onPartialToolCall(toolFetcher.buildPartial());
                     }
 
                     if (nonNull(message.delta().content())) {
@@ -307,6 +315,7 @@ public interface ChatProvider {
                         toolCalls = tools.stream()
                             .map(StreamingToolFetcher::build)
                             .toList();
+                        handler.onCompleteToolCall(toolCalls.get(toolCalls.size() - 1));
                     }
 
                     var resultMessage = new ResultMessage(role, content, refusal, toolCalls);

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
@@ -17,6 +17,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
+import com.ibm.watsonx.ai.chat.model.FinishReason;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.core.Json;
 import com.ibm.watsonx.ai.core.XmlUtils;
@@ -346,5 +347,18 @@ public final class ChatResponse {
         var resultMessage = choices.get(0).message();
         return new AssistantMessage(AssistantMessage.ROLE, resultMessage.content(), null, resultMessage.refusal(),
             resultMessage.toolCalls());
+    }
+
+    /**
+     * Retrieves the finish reason for the current chat response.
+     *
+     * @return a {@code String} representing the reason why the response generation finished d
+     */
+    public FinishReason finishReason() {
+        if (isNull(choices) || choices.isEmpty())
+            throw new RuntimeException("The \"choices\" field is null or empty");
+
+        var resultMessage = choices.get(0);
+        return FinishReason.fromValue(resultMessage.finishReason());
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/FinishReason.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/FinishReason.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat.model;
+
+/**
+ * Represents the reason why a chat or completion generation stopped.
+ */
+public enum FinishReason {
+
+    /**
+     * The model reached a natural stopping point or encountered a provided stop sequence.
+     */
+    STOP("stop"),
+
+    /**
+     * The maximum number of tokens specified in the request was reached.
+     */
+    LENGTH("length"),
+
+    /**
+     * The model decided to call an external tool.
+     */
+    TOOL_CALLS("tool_calls"),
+
+    /**
+     * The generation stopped because the allowed time limit was reached.
+     */
+    TIME_LIMIT("time_limit"),
+
+    /**
+     * The request was cancelled by the client before completion.
+     */
+    CANCELLED("cancelled"),
+
+    /**
+     * An error occurred during the generation process.
+     */
+    ERROR("error"),
+
+    /**
+     * The API response is still in progress.
+     */
+    INCOMPLETE(null);
+
+    private final String value;
+
+    FinishReason(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value used by the API for this finish reason.
+     *
+     * @return the string value
+     */
+    public String value() {
+        return value;
+    }
+
+    /**
+     * Maps a string value returned by the API to the corresponding {@link FinishReason} enum.
+     *
+     * @param value the finish reason value, can be {@code null}
+     * @return the matching {@link FinishReason}, or {@link #INCOMPLETE} if the value is {@code null} or unrecognized
+     */
+    public static FinishReason fromValue(String value) {
+        if (value == null) {
+            return INCOMPLETE;
+        }
+        for (FinishReason reason : values()) {
+            if (value.equals(reason.value)) {
+                return reason;
+            }
+        }
+        throw new IllegalArgumentException("Unknown finish reason: " + value);
+    }
+}
+

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/StreamingToolFetcher.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/StreamingToolFetcher.java
@@ -13,6 +13,8 @@ import java.util.UUID;
  */
 public final class StreamingToolFetcher {
 
+    public record PartialToolCall(int index, String id, String name, String arguments) {}
+
     private int index;
     private StringBuilder arguments;
     private String id, name;
@@ -35,6 +37,10 @@ public final class StreamingToolFetcher {
     public void appendArguments(String arguments) {
         if (nonNull(arguments))
             this.arguments.append(arguments);
+    }
+
+    public PartialToolCall buildPartial() {
+        return new PartialToolCall(index, id, name, arguments.toString());
     }
 
     public ToolCall build() {

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/DeploymentServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/DeploymentServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
@@ -52,7 +53,9 @@ import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
+import com.ibm.watsonx.ai.chat.model.StreamingToolFetcher.PartialToolCall;
 import com.ibm.watsonx.ai.chat.model.SystemMessage;
+import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
@@ -550,6 +553,16 @@ public class DeploymentServiceTest {
             @Override
             public void onError(Throwable error) {
                 result.completeExceptionally(error);
+            }
+
+            @Override
+            public void onPartialToolCall(PartialToolCall partialToolCall) {
+                fail();
+            }
+
+            @Override
+            public void onCompleteToolCall(ToolCall completeToolCall) {
+                fail();
             }
         };
 

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/FinishReasonTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/FinishReasonTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import com.ibm.watsonx.ai.chat.model.FinishReason;
+
+public class FinishReasonTest {
+
+    @Test
+    void test_finish_reason() {
+        assertEquals("cancelled", FinishReason.CANCELLED.value());
+        assertEquals("error", FinishReason.ERROR.value());
+        assertEquals(null, FinishReason.INCOMPLETE.value());
+        assertEquals("length", FinishReason.LENGTH.value());
+        assertEquals("stop", FinishReason.STOP.value());
+        assertEquals("time_limit", FinishReason.TIME_LIMIT.value());
+        assertEquals("tool_calls", FinishReason.TOOL_CALLS.value());
+
+        assertEquals(FinishReason.CANCELLED, FinishReason.fromValue("cancelled"));
+        assertEquals(FinishReason.ERROR, FinishReason.fromValue("error"));
+        assertEquals(FinishReason.INCOMPLETE, FinishReason.fromValue(null));
+        assertEquals(FinishReason.LENGTH, FinishReason.fromValue("length"));
+        assertEquals(FinishReason.STOP, FinishReason.fromValue("stop"));
+        assertEquals(FinishReason.TIME_LIMIT, FinishReason.fromValue("time_limit"));
+        assertEquals(FinishReason.TOOL_CALLS, FinishReason.fromValue("tool_calls"));
+        assertThrows(IllegalArgumentException.class, () -> FinishReason.fromValue("unknown"), "Unknown finish reason: unknown");
+    }
+}

--- a/samples/chatbot-streaming-tools/README.md
+++ b/samples/chatbot-streaming-tools/README.md
@@ -1,0 +1,39 @@
+# Watsonx Chatbot Example
+
+This is a simple chatbot project that uses streaming with tools.
+
+## Prerequisites
+
+Before running the application, set the following environment variables or create a new `.env` file in the project's root folder:
+
+| Variable              | Required | Description |
+|-----------------------|----------|-------------|
+| `WATSONX_API_KEY`     | Yes      | watsonx.ai API key |
+| `WATSONX_URL`         | Yes      | The base URL for the watsonx.ai service |
+| `WATSONX_PROJECT_ID`  | Yes      | watsonx.ai project id |
+| `WATSONX_MODEL_ID`    | No       | watsonx.ai model id. If not set, a default LLM will be used. When setting this variable, use a value from the `API model ID` column in the [IBM provided models list](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx#ibm-provided). |
+
+> **Important:** the chosen model must support the use of Tools.
+
+Example (Linux/macOS):
+```bash
+export WATSONX_API_KEY=api-key
+export WATSONX_URL=https://watsonx-url
+export WATSONX_PROJECT_ID=project-id
+# Optional: export WATSONX_MODEL_ID=model-id
+```
+
+Example (Windows CMD):
+```cmd
+set WATSONX_API_KEY=api-key
+set WATSONX_URL=https://watsonx-url
+set WATSONX_PROJECT_ID=project-id
+:: Optional: set WATSONX_MODEL_ID=model-id
+```
+
+## How to Run
+Use Maven to run the application:
+
+```bash
+mvn package exec:java
+```

--- a/samples/chatbot-streaming-tools/pom.xml
+++ b/samples/chatbot-streaming-tools/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.watsonx</groupId>
+  <artifactId>watsonx-ai-sample-streaming-chatbot-tools</artifactId>
+  <version>0.5.0</version>
+  <name>Streaming Chatbot Tools Sample</name>
+
+  <parent>
+    <groupId>com.ibm.watsonx</groupId>
+    <artifactId>watsonx-ai-sample-parent</artifactId>
+    <version>0.5.0</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <mainClass>com.ibm.chatbot.App</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/AiService.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.chatbot;
+
+import static com.ibm.watsonx.ai.foundationmodel.filter.Filter.Expression.modelId;
+import static java.util.Objects.nonNull;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import com.ibm.chatbot.Tools.SendEmailArguments;
+import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatResponse;
+import com.ibm.watsonx.ai.chat.ChatService;
+import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.JsonSchema;
+import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
+import com.ibm.watsonx.ai.chat.model.SystemMessage;
+import com.ibm.watsonx.ai.chat.model.Tool;
+import com.ibm.watsonx.ai.chat.model.ToolMessage;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
+import com.ibm.watsonx.ai.core.Json;
+import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
+import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
+import com.ibm.watsonx.ai.foundationmodel.filter.Filter;
+
+public class AiService {
+
+    private static final Config config = ConfigProvider.getConfig();
+    private static final String SYSTEM_MESSAGE = """
+        You are a helpful assistant. Your task is to answer user questions.
+        Since the response will be written in a CLI, keep your answers concise to ensure readability.""";
+
+    private static final Tool EMAIL_TOOL = Tool.of(
+        "send_email",
+        "Send an email",
+        JsonSchema.builder()
+            .addStringProperty("email")
+            .addStringProperty("subject")
+            .addStringProperty("body")
+            .required("email", "subject", "body")
+    );
+
+    private String modelId;
+    private final ChatService chatService;
+    private final FoundationModelService foundationModelService;
+    private final ChatMemory memory;
+
+    public AiService() {
+        var url = URI.create(config.getValue("WATSONX_URL", String.class));
+        var apiKey = config.getValue("WATSONX_API_KEY", String.class);
+        var projectId = config.getValue("WATSONX_PROJECT_ID", String.class);
+        modelId = config.getOptionalValue("WATSONX_MODEL_ID", String.class).orElse("mistralai/mistral-small-3-1-24b-instruct-2503");
+
+        AuthenticationProvider authProvider = IAMAuthenticator.builder()
+            .apiKey(apiKey)
+            .timeout(Duration.ofSeconds(60))
+            .build();
+
+        chatService = ChatService.builder()
+            .authenticationProvider(authProvider)
+            .projectId(projectId)
+            .timeout(Duration.ofSeconds(60))
+            .modelId(modelId)
+            .url(url)
+            .build();
+
+        foundationModelService = FoundationModelService.builder()
+            .authenticationProvider(authProvider)
+            .url(url)
+            .timeout(Duration.ofSeconds(60))
+            .build();
+
+        memory = new ChatMemory();
+        memory.addMessage(SystemMessage.of(SYSTEM_MESSAGE));
+    }
+
+
+    public CompletableFuture<AssistantMessage> chat(String message, Consumer<String> handler) {
+
+        memory.addMessage(UserMessage.text(message));
+
+        CompletableFuture<AssistantMessage> future = new CompletableFuture<>();
+        future.thenAccept(memory::addMessage);
+
+        chatService.chatStreaming(memory.getMemory(), List.of(EMAIL_TOOL), new ChatHandler() {
+
+            @Override
+            public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
+                handler.accept(partialResponse);
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                var assistantMessage = completeResponse.toAssistantMessage();
+
+                if (nonNull(assistantMessage.toolCalls())) {
+                    handleToolCalls(assistantMessage, this)
+                        .whenComplete((res, err) -> {
+                            if (err != null) {
+                                future.completeExceptionally(err);
+                            } else {
+                                future.complete(assistantMessage);
+                            }
+                        });
+                } else {
+                    future.complete(assistantMessage);
+                }
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        return future;
+    }
+
+    private CompletableFuture<Void> handleToolCalls(AssistantMessage assistantMessage, ChatHandler chatHandler) {
+        List<ChatMessage> messages = new ArrayList<>(memory.getMemory());
+        messages.add(assistantMessage);
+
+        for (var toolCall : assistantMessage.toolCalls()) {
+            var args = Json.fromJson(toolCall.function().arguments(), SendEmailArguments.class);
+            var result = Tools.sendEmail(args.email(), args.subject(), args.body());
+            messages.add(ToolMessage.of(String.valueOf(result), toolCall.id()));
+        }
+
+        return chatService.chatStreaming(messages, chatHandler);
+    }
+
+    public FoundationModel getModel() {
+        return foundationModelService.getModels(Filter.of(modelId(modelId))).resources().get(0);
+    }
+}

--- a/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/App.java
+++ b/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/App.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.chatbot;
+
+import java.util.Scanner;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
+
+public class App {
+
+    private static final AiService aiService = new AiService();
+
+    public static void main(String[] args) throws Exception {
+
+        FoundationModel foundationModel = aiService.getModel();
+        System.out.println("Welcome to the IBM Watsonx Assistant Chatbot!");
+        System.out.println("""
+            ---------------------------------------------
+            Model: %s
+            Max Sequence Length: %s
+            Max Output Tokens: %s
+            ---------------------------------------------""".formatted(
+            foundationModel.modelId(), foundationModel.maxSequenceLength(),
+            foundationModel.maxOutputTokens()
+        ));
+        System.out.println("Type your message and press enter to send it:\n");
+
+        try (Scanner scanner = new Scanner(System.in)) {
+            while (true) {
+                System.out.print("You: ");
+                String userInput = scanner.nextLine();
+                System.out.print("Assistant: ");
+                aiService.chat(userInput, System.out::print).get();
+                System.out.println("\n");
+            }
+        }
+    }
+}

--- a/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/ChatMemory.java
+++ b/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/ChatMemory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.chatbot;
+
+import java.util.LinkedList;
+import java.util.List;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.SystemMessage;
+
+public class ChatMemory {
+
+    private static final int MAX_SIZE = 10;
+    private List<ChatMessage> memory;
+
+    public ChatMemory() {
+        memory = new LinkedList<>();
+    }
+
+    public void addMessage(ChatMessage message) {
+        if (memory.size() >= MAX_SIZE) {
+            var index = 0;
+            if (memory.get(0) instanceof SystemMessage)
+                index = 1;
+            memory.remove(index);
+        }
+
+        memory.add(message);
+    }
+
+    public List<ChatMessage> getMemory() {
+        return memory;
+    }
+}

--- a/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/Tools.java
+++ b/samples/chatbot-streaming-tools/src/main/java/com/ibm/chatbot/Tools.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.chatbot;
+
+public class Tools {
+
+
+    public record SendEmailArguments(String email, String subject, String body) {};
+
+    public static boolean sendEmail(String to, String subject, String body) {
+        System.out.println("""
+
+            ----------------------------------------
+            Executed sendEmail function with parameters:
+            Email sent to: %s
+            Subject: %s
+            Body: %s
+            ----------------------------------------""".formatted(to, subject, body));
+        return true;
+    }
+}

--- a/samples/chatbot-streaming-tools/src/main/resources/log4j2.xml
+++ b/samples/chatbot-streaming-tools/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%p] %d{yyyy-MM-dd HH:mm:ss} %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/samples/chatbot-streaming/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot-streaming/src/main/java/com/ibm/chatbot/AiService.java
@@ -17,7 +17,9 @@ import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
+import com.ibm.watsonx.ai.chat.model.StreamingToolFetcher.PartialToolCall;
 import com.ibm.watsonx.ai.chat.model.SystemMessage;
+import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
@@ -85,6 +87,16 @@ public class AiService {
             @Override
             public void onError(Throwable error) {
                 System.err.println(error);
+            }
+
+            @Override
+            public void onPartialToolCall(PartialToolCall partialToolCall) {
+                // No tool calls
+            }
+
+            @Override
+            public void onCompleteToolCall(ToolCall completeToolCall) {
+                // No tool calls
             }
         });
     }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,6 +12,7 @@
     <module>chatbot</module>
     <module>chatbot-streaming</module>
     <module>chatbot-tools</module>
+    <module>chatbot-streaming-tools</module>
     <module>image-analyzer</module>
     <module>embedding-text</module>
     <module>rerank</module>


### PR DESCRIPTION
Introduced two new default callback methods in the chat streaming listener interface:

- `onPartialToolCall(PartialToolCall partialToolCall)` – Invoked whenever a partial tool call is detected during the streaming process.
Allows developers to handle incremental tool call arguments or metadata as they arrive in chunks.
- `onCompleteToolCall(ToolCall completeToolCall)` – Invoked once the tool call is fully received and constructed.
Enables developers to trigger downstream actions only when the complete tool call is available.