### PR TITLE
Set default IOExecutor threads as daemon for proper shutdown

### DIFF
--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/provider/ExecutorProvider.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/provider/ExecutorProvider.java
@@ -77,7 +77,11 @@ public class ExecutorProvider {
                 .orElse(Runtime.getRuntime().availableProcessors());
 
             AtomicInteger counter = new AtomicInteger(1);
-            ExecutorService defaultExecutor = Executors.newFixedThreadPool(nThreads, r -> new Thread(r, "io-thread-" + counter.getAndIncrement()));
+            ExecutorService defaultExecutor = Executors.newFixedThreadPool(nThreads, r -> {
+                var thread = new Thread(r, "io-thread-" + counter.getAndIncrement());
+                thread.setDaemon(true);
+                return thread;
+            });
 
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 defaultExecutor.shutdown();

--- a/samples/chatbot-streaming-reasoning/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot-streaming-reasoning/src/main/java/com/ibm/chatbot/AiService.java
@@ -53,7 +53,6 @@ public class AiService {
             .projectId(projectId)
             .timeout(Duration.ofSeconds(60))
             .modelId(modelId)
-            .logRequests(true)
             .url(url)
             .build();
 


### PR DESCRIPTION
Ensure threads created by the default IOExecutor are daemon threads, allowing JVM to shut down cleanly.