### PR TITLE
Add automatic `Watsonx-AI-SDK-Request-Id` header

### DIFF
--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/AsyncHttpClient.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/AsyncHttpClient.java
@@ -59,7 +59,7 @@ public final class AsyncHttpClient extends BaseHttpClient {
      * @return a {@link CompletableFuture} of the HTTP response
      */
     public <T> CompletableFuture<HttpResponse<T>> send(HttpRequest request, BodyHandler<T> handler) {
-        return send(request, handler, executor());
+        return send(addRequestIdHeaderIfNotPresent(request), handler, executor());
     }
 
     /**

--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/BaseHttpClient.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/BaseHttpClient.java
@@ -5,6 +5,8 @@
 package com.ibm.watsonx.ai.core.http;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import com.ibm.watsonx.ai.core.provider.ExecutorProvider;
 
@@ -15,6 +17,8 @@ import com.ibm.watsonx.ai.core.provider.ExecutorProvider;
  * @see AsyncHttpClient
  */
 public abstract class BaseHttpClient {
+
+    public static final String REQUEST_ID_HEADER = "Watsonx-AI-SDK-Request-Id";
 
     final HttpClient delegate;
 
@@ -34,5 +38,19 @@ public abstract class BaseHttpClient {
      */
     public Executor executor() {
         return delegate.executor().orElse(ExecutorProvider.ioExecutor());
+    }
+
+    /**
+     * Adds a {@code Watsonx-AI-SDK-Request-Id} header to the given HTTP request if it is not already present.
+     *
+     * @param request the HTTP request to which the header will be added
+     * @return the HTTP request with the added or existing request ID header
+     */
+    protected HttpRequest addRequestIdHeaderIfNotPresent(HttpRequest request) {
+        return request.headers()
+            .firstValue(REQUEST_ID_HEADER).map(h -> request)
+            .orElse(HttpRequest.newBuilder(request, (k, v) -> true)
+                .header(REQUEST_ID_HEADER, UUID.randomUUID().toString())
+                .build());
     }
 }

--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/SyncHttpClient.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/SyncHttpClient.java
@@ -58,7 +58,7 @@ public final class SyncHttpClient extends BaseHttpClient {
      */
     public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> bodyHandler)
         throws WatsonxException, IOException, InterruptedException {
-        return new InterceptorChain(delegate, interceptors).proceed(request, bodyHandler);
+        return new InterceptorChain(delegate, interceptors).proceed(addRequestIdHeaderIfNotPresent(request), bodyHandler);
     }
 
     /**

--- a/modules/watsonx-ai-core/src/test/resources/log4j2.xml
+++ b/modules/watsonx-ai-core/src/test/resources/log4j2.xml
@@ -2,15 +2,16 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} - %msg%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] - %msg%n" />
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.ibm.watsonx.ai.core.http.interceptors.RetryInterceptor" level="debug">
-            <AppenderRef ref="Console"/>
+        <Logger name="com.ibm.watsonx.ai.core.http.interceptors.RetryInterceptor" level="debug"
+            additivity="false">
+            <AppenderRef ref="Console" />
         </Logger>
         <Root level="info">
-            <AppenderRef ref="Console"/>
+            <AppenderRef ref="Console" />
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Introduce a `Watsonx-AI-SDK-Request-Id` header automatically if not already present in both sync and async HTTP clients. This ensures consistent request tracking across all outgoing requests.