### PR TITLE
Add RetryInterceptor for retryable HTTP status codes

### DIFF
--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/HttpUtils.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/HttpUtils.java
@@ -70,7 +70,7 @@ public final class HttpUtils {
 
         try {
             if (body instanceof String str) {
-                return Optional.of(str);
+                return str.isBlank() ? Optional.empty() : Optional.of(str);
             } else if (body instanceof byte[] bytes) {
                 return Optional.of(new String(bytes, StandardCharsets.UTF_8));
             } else if (body instanceof InputStream inputStream) {

--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/AsyncHttpClient.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/AsyncHttpClient.java
@@ -115,7 +115,7 @@ public final class AsyncHttpClient extends BaseHttpClient {
                         BodySubscribers.ofString(StandardCharsets.UTF_8),
                         body -> {
                             if (body.isEmpty())
-                                throw new WatsonxException(statusCode);
+                                throw new WatsonxException("Status code: " + statusCode, statusCode, null);
 
                             String contentType = responseInfo.headers().firstValue("Content-Type")
                                 .orElseThrow(() -> new WatsonxException(body, statusCode, null));

--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/SyncHttpClient.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/SyncHttpClient.java
@@ -96,14 +96,13 @@ public final class SyncHttpClient extends BaseHttpClient {
             HttpResponse<T> httpResponse = client.send(request, bodyHandler);
             int statusCode = httpResponse.statusCode();
 
-            if (statusCode >= 200 && statusCode < 300) {
+            if (statusCode >= 200 && statusCode < 300)
                 return httpResponse;
-            }
 
             Optional<String> bodyOpt = HttpUtils.extractBodyAsString(httpResponse);
-            if (bodyOpt.isEmpty()) {
-                throw new WatsonxException(statusCode);
-            }
+
+            if (bodyOpt.isEmpty())
+                throw new WatsonxException("Status code: " + statusCode, statusCode, null);
 
             String body = bodyOpt.get();
             String contentType = httpResponse.headers().firstValue("Content-Type")

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
@@ -72,15 +72,17 @@ public abstract class WatsonxService {
         var syncHttpClientBuilder = SyncHttpClient.builder().httpClient(httpClient);
         var asyncHttpClientBuilder = AsyncHttpClient.builder().httpClient(httpClient);
 
-        var retryInterceptor = RetryInterceptor.onTokenExpired(1);
-        syncHttpClientBuilder.interceptor(retryInterceptor);
-        asyncHttpClientBuilder.interceptor(retryInterceptor);
+        syncHttpClientBuilder.interceptor(RetryInterceptor.ON_TOKEN_EXPIRED);
+        asyncHttpClientBuilder.interceptor(RetryInterceptor.ON_TOKEN_EXPIRED);
 
         if (nonNull(builder.authenticationProvider)) {
             var bearerInterceptor = new BearerInterceptor(builder.authenticationProvider);
             syncHttpClientBuilder.interceptor(bearerInterceptor);
             asyncHttpClientBuilder.interceptor(bearerInterceptor);
         }
+
+        syncHttpClientBuilder.interceptor(RetryInterceptor.ON_RETRYABLE_STATUS_CODES);
+        asyncHttpClientBuilder.interceptor(RetryInterceptor.ON_RETRYABLE_STATUS_CODES);
 
         if (logRequests || logResponses) {
             syncHttpClientBuilder.interceptor(new LoggerInterceptor(logRequests, logResponses));

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
@@ -22,6 +22,7 @@ import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.chat.util.StreamingStateTracker;
 import com.ibm.watsonx.ai.chat.util.StreamingToolFetcher;
 import com.ibm.watsonx.ai.chat.util.StreamingToolFetcher.PartialToolCall;
@@ -36,6 +37,16 @@ import com.ibm.watsonx.ai.deployment.DeploymentService;
  * @see DeploymentService
  */
 public interface ChatProvider {
+
+    /**
+     * Sends a chat request to the model using the provided message.
+     *
+     * @param message Message to send.
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public default ChatResponse chat(String message) {
+        return chat(UserMessage.text(message));
+    }
 
     /**
      * Sends a chat request to the model using the provided messages.
@@ -134,6 +145,16 @@ public interface ChatProvider {
                 .tools(tools)
                 .build()
         );
+    }
+
+    /**
+     * Sends a chat request to the model using the provided message.
+     *
+     * @param message Message to send.
+     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
+     */
+    public default CompletableFuture<Void> chatStreaming(String message, ChatHandler handler) {
+        return chatStreaming(List.of(UserMessage.text(message)), handler);
     }
 
     /**

--- a/modules/watsonx-ai/src/test/resources/log4j2.xml
+++ b/modules/watsonx-ai/src/test/resources/log4j2.xml
@@ -2,12 +2,16 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} - %msg%n" />
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] - %msg%n" />
         </Console>
     </Appenders>
     <Loggers>
+        <Logger name="com.ibm.watsonx.ai.core.http.interceptors.RetryInterceptor" level="debug"
+            additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
         <Root level="info">
-            <AppenderRef ref="Console"/>
+            <AppenderRef ref="Console" />
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
- Introduced `RetryInterceptor.ON_RETRYABLE_STATUS_CODES` to handle retryable HTTP responses (`429`, `503`, `504`, `520`).
- Updated WatsonxService to include this interceptor for both sync and async clients.