### PR TITLE
Refactor streaming toolcall

### DIFF
--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatHandler.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatHandler.java
@@ -4,10 +4,10 @@
  */
 package com.ibm.watsonx.ai.chat;
 
+import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
-import com.ibm.watsonx.ai.chat.model.ToolCall;
-import com.ibm.watsonx.ai.chat.util.StreamingToolFetcher.PartialToolCall;
+import com.ibm.watsonx.ai.chat.model.PartialToolCall;
 
 /**
  * Interface for handling streaming chat responses.
@@ -41,21 +41,23 @@ public interface ChatHandler {
     void onError(Throwable error);
 
     /**
-     * Called whenever a partial tool call is detected during the chat streaming process. This method may be invoked multiple times if the model
-     * streams tool call arguments or metadata in chunks.
+     * This callback is invoked each time the model generates a partial tool call, which may contain a fragment (token) of the tool's arguments.
+     * <p>
+     * It is typically invoked multiple times for a single tool call until {@link #onCompleteToolCall(CompletedToolCall)} is invoked, indicating that
+     * the tool call is fully assembled.
      *
-     * @param partialToolCall the partial chunk of the tool call received
+     * @param partialToolCall A partial tool call fragment containing index, tool ID, tool name, and partial arguments.
      */
     default void onPartialToolCall(PartialToolCall partialToolCall) {
         // Invoked whenever a partial tool call is detected during the streaming process
     }
 
     /**
-     * Called once a tool call has been fully received.
+     * Invoked once the model has finished streaming a single tool call and the arguments are fully assembled.
      *
-     * @param completeToolCall the fully constructed tool call
+     * @param completeToolCall The completed tool call.
      */
-    default void onCompleteToolCall(ToolCall completeToolCall) {
+    default void onCompleteToolCall(CompletedToolCall completeToolCall) {
         // Allows triggering actions as soon as the complete tool call is available, without necessarily waiting for the full assistant response to
         // finish streaming.
     }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/CompletedToolCall.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/CompletedToolCall.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat.model;
+
+import com.ibm.watsonx.ai.chat.ChatResponse;
+
+/**
+ * Represents a fully assembled tool call emitted during chat completion streaming.
+ * <p>
+ * Unlike the final {@link ChatResponse}, which is delivered only once the entire assistant reply has finished streaming, a {@code CompletedToolCall}
+ * is emitted as soon as a single tool call has been completely received. This means that multiple {@code CompletedToolCall} events may occur within
+ * the same chat response, if the model decides to call more than one tool.
+ *
+ * @param completionId The identifier of the chat completion request this tool call belongs to.
+ * @param toolCall The fully constructed {@link ToolCall}.
+ */
+public record CompletedToolCall(String completionId, ToolCall toolCall) {
+
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/PartialToolCall.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/PartialToolCall.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat.model;
+
+/**
+ * Represents a partial tool call emitted during chat completion streaming.
+ * <p>
+ * This object may be produced multiple times for a single tool call, typically containing incremental fragments (tokens) of the tool's arguments as
+ * they are streamed by the model. Once all fragments have been received and assembled, a {@link CompletedToolCall} will be delivered instead.
+ *
+ * @param completionId The identifier of the chat completion request this tool call belongs to
+ * @param index The index of this tool call within the choices array (correlates fragments)
+ * @param id The identifier of the tool call
+ * @param name The function name being invoked
+ * @param arguments A partial fragment of the function arguments (JSON string may be incomplete)
+ */
+public record PartialToolCall(String completionId, int index, String id, String name, String arguments) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/util/StreamingToolFetcher.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/util/StreamingToolFetcher.java
@@ -14,8 +14,6 @@ import com.ibm.watsonx.ai.chat.model.ToolCall;
  */
 public final class StreamingToolFetcher {
 
-    public record PartialToolCall(int index, String id, String name, String arguments) {}
-
     private volatile int index;
     private StringBuffer arguments;
     private volatile String id, name;

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/DeploymentServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/DeploymentServiceTest.java
@@ -54,14 +54,14 @@ import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.ChatParameters.ToolChoice;
+import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.ControlMessage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
+import com.ibm.watsonx.ai.chat.model.PartialToolCall;
 import com.ibm.watsonx.ai.chat.model.SystemMessage;
 import com.ibm.watsonx.ai.chat.model.TextChatRequest;
-import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
-import com.ibm.watsonx.ai.chat.util.StreamingToolFetcher.PartialToolCall;
 import com.ibm.watsonx.ai.core.provider.ExecutorProvider;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
 import com.ibm.watsonx.ai.deployment.FindByIdParameters;
@@ -561,7 +561,7 @@ public class DeploymentServiceTest extends AbstractWatsonxTest {
             }
 
             @Override
-            public void onCompleteToolCall(ToolCall completeToolCall) {
+            public void onCompleteToolCall(CompletedToolCall completeToolCall) {
                 fail();
             }
         };
@@ -688,7 +688,7 @@ public class DeploymentServiceTest extends AbstractWatsonxTest {
             }
 
             @Override
-            public void onCompleteToolCall(ToolCall completeToolCall) {
+            public void onCompleteToolCall(CompletedToolCall completeToolCall) {
                 fail();
             }
         }).get(3, TimeUnit.SECONDS);

--- a/samples/chatbot-streaming/src/main/java/com/ibm/chatbot/AiService.java
+++ b/samples/chatbot-streaming/src/main/java/com/ibm/chatbot/AiService.java
@@ -17,9 +17,7 @@ import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
 import com.ibm.watsonx.ai.chat.model.SystemMessage;
-import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
-import com.ibm.watsonx.ai.chat.util.StreamingToolFetcher.PartialToolCall;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
@@ -86,16 +84,6 @@ public class AiService {
             @Override
             public void onError(Throwable error) {
                 System.err.println(error);
-            }
-
-            @Override
-            public void onPartialToolCall(PartialToolCall partialToolCall) {
-                // No tool calls
-            }
-
-            @Override
-            public void onCompleteToolCall(ToolCall completeToolCall) {
-                // No tool calls
             }
         });
     }


### PR DESCRIPTION
Introduce `CompletedToolCall` and extend `PartialToolCall` with completionId

- Added new `CompletedToolCall` record to represent fully assembled tool calls during streaming.
- Extended `PartialToolCall` by adding a `completionId`.
- Updated `ChatHandler` interface to use `CompletedToolCall` and `PartialToolCall`.
- Refactored `ChatProvider` to emit enriched tool call events, passing `completionId` for correlation.
- Removed `PartialToolCall` definition from `StreamingToolFetcher`.
