### PR TITLE
Refactor service interfaces to use request objects

### DIFF
--- a/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/interceptors/RetryInterceptor.java
+++ b/modules/watsonx-ai-core/src/main/java/com/ibm/watsonx/ai/core/http/interceptors/RetryInterceptor.java
@@ -185,9 +185,16 @@ public final class RetryInterceptor implements SyncHttpInterceptor, AsyncHttpInt
                             .orElse(true);
                     });
 
-                if (!shouldRetry || attempt >= maxRetries) {
-                    if (shouldRetry)
-                        logger.debug("Max retries reached for request \"{}\"", requestId);
+                var shouldFail = false;
+
+                if (!shouldRetry) {
+                    shouldFail = true;
+                } else if (attempt >= maxRetries) {
+                    logger.debug("Max retries ({}) reached for request \"{}\"", maxRetries, requestId);
+                    shouldFail = true;
+                }
+
+                if (shouldFail) {
                     CompletableFuture<HttpResponse<T>> failed = new CompletableFuture<>();
                     failed.completeExceptionally(cause);
                     return failed;

--- a/modules/watsonx-ai-core/src/test/java/com/ibm/watsonx/ai/core/BearerInterceptorTest.java
+++ b/modules/watsonx-ai-core/src/test/java/com/ibm/watsonx/ai/core/BearerInterceptorTest.java
@@ -205,7 +205,7 @@ public class BearerInterceptorTest extends AbstractWatsonxTest {
                 assertDoesNotThrow(() -> client.send(HttpRequest.newBuilder()
                     .uri(URI.create("https://test.com"))
                     .GET().build(), BodyHandlers.ofString())
-                    .thenRun(() -> threadNames.add(Thread.currentThread().getName()))
+                    .thenRunAsync(() -> threadNames.add(Thread.currentThread().getName()), ioExecutor)
                     .get(3, TimeUnit.SECONDS));
 
                 assertEquals(4, threadNames.size());

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
@@ -86,7 +86,7 @@ public abstract class WatsonxService {
 
         if (logRequests || logResponses) {
             syncHttpClientBuilder.interceptor(new LoggerInterceptor(logRequests, logResponses));
-            asyncHttpClientBuilder.interceptor(new LoggerInterceptor(logRequests, false));
+            asyncHttpClientBuilder.interceptor(new LoggerInterceptor(logRequests, logResponses));
         }
 
         syncHttpClient = syncHttpClientBuilder.build();

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
@@ -8,7 +8,6 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +24,6 @@ import com.ibm.watsonx.ai.chat.model.PartialToolCall;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
-import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.chat.util.StreamingStateTracker;
 import com.ibm.watsonx.ai.chat.util.StreamingToolFetcher;
 import com.ibm.watsonx.ai.core.Json;
@@ -38,187 +36,6 @@ import com.ibm.watsonx.ai.deployment.DeploymentService;
  * @see DeploymentService
  */
 public interface ChatProvider {
-
-    /**
-     * Sends a chat request to the model using the provided message.
-     *
-     * @param message Message to send.
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(String message) {
-        return chat(UserMessage.text(message));
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(ChatMessage... messages) {
-        return chat(Arrays.asList(messages));
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-
-    public default ChatResponse chat(List<ChatMessage> messages) {
-        return chat(messages, ChatParameters.builder().build());
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages and tools.
-     * <p>
-     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, include
-     * {@link Tool} definitions for function-calling models.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @param tools list of tools the model may call during generation
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(List<ChatMessage> messages, Tool... tools) {
-        return chat(messages, Arrays.asList(tools));
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages and tools.
-     * <p>
-     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, include
-     * {@link Tool} definitions for function-calling models.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @param tools list of tools the model may call during generation
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(List<ChatMessage> messages, List<Tool> tools) {
-        return chat(messages, null, tools);
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages, and parameters.
-     * <p>
-     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, and customize
-     * the generation behavior via {@link ChatParameters}.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @param parameters parameters to customize the output generation
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(List<ChatMessage> messages, ChatParameters parameters) {
-        return chat(messages, parameters, List.of());
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages, and parameters.
-     * <p>
-     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, and customize
-     * the generation behavior via {@link ChatParameters}.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @param parameters parameters to customize the output generation
-     * @param tools list of tools the model may call during generation
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(List<ChatMessage> messages, ChatParameters parameters, Tool... tools) {
-        return chat(messages, parameters, Arrays.asList(tools));
-    }
-
-    /**
-     * Sends a chat request to the model using the provided messages, and parameters.
-     * <p>
-     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, and customize
-     * the generation behavior via {@link ChatParameters}.
-     *
-     * @param messages the list of chat messages representing the conversation history
-     * @param parameters parameters to customize the output generation
-     * @param tools list of tools the model may call during generation
-     * @return a {@link ChatResponse} object containing the model's reply
-     */
-    public default ChatResponse chat(List<ChatMessage> messages, ChatParameters parameters, List<Tool> tools) {
-        return chat(
-            ChatRequest.builder()
-                .messages(messages)
-                .parameters(parameters)
-                .tools(tools)
-                .build()
-        );
-    }
-
-    /**
-     * Sends a chat request to the model using the provided message.
-     *
-     * @param message Message to send.
-     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
-     */
-    public default CompletableFuture<Void> chatStreaming(String message, ChatHandler handler) {
-        return chatStreaming(List.of(UserMessage.text(message)), handler);
-    }
-
-    /**
-     * Sends a streaming chat request using the provided messages.
-     * <p>
-     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
-     * {@link ChatHandler}.
-     *
-     * @param messages the list of chat messages forming the prompt history
-     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
-     */
-    public default CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, ChatHandler handler) {
-        return chatStreaming(messages, ChatParameters.builder().build(), handler);
-    }
-
-    /**
-     * Sends a streaming chat request using the provided messages.
-     * <p>
-     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
-     * {@link ChatHandler}.
-     *
-     * @param messages the list of chat messages forming the prompt history
-     * @param tools the list of tools that the model may use
-     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
-     */
-    public default CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, List<Tool> tools, ChatHandler handler) {
-        return chatStreaming(messages, ChatParameters.builder().build(), tools, handler);
-    }
-
-    /**
-     * Sends a streaming chat request using the provided messages.
-     * <p>
-     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
-     * {@link ChatHandler}.
-     *
-     * @param messages the list of chat messages forming the prompt history
-     * @param parameters additional optional parameters for the chat invocation
-     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
-     */
-    public default CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, ChatParameters parameters, ChatHandler handler) {
-        return chatStreaming(messages, parameters, null, handler);
-    }
-
-    /**
-     * Sends a streaming chat request using the provided messages.
-     * <p>
-     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
-     * {@link ChatHandler}.
-     *
-     * @param messages the list of chat messages forming the prompt history
-     * @param parameters additional optional parameters for the chat invocation
-     * @param tools the list of tools that the model may use
-     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
-     */
-    public default CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, ChatParameters parameters, List<Tool> tools,
-        ChatHandler handler) {
-        var chatRequest = ChatRequest.builder()
-            .messages(messages)
-            .parameters(parameters)
-            .tools(tools)
-            .build();
-        return chatStreaming(chatRequest, handler);
-    }
 
     /**
      * Sends a chat request to the model using the provided messages, tools, and parameters.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatRequest.java
@@ -10,9 +10,10 @@ import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.Tool;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
 
 /**
- * Represents a chat request sent to the model.
+ * Represents a chat request.
  * <p>
  * Instances are created using the {@link Builder} pattern:
  * <p>
@@ -37,26 +38,29 @@ import com.ibm.watsonx.ai.chat.model.Tool;
  * ChatRequest request = ChatRequest.builder()
  *     .messages(
  *         SystemMessage.of("You are a helpful assistant"),
- *         UserMessage.text("Tell me a joke")
- *     )
+ *         UserMessage.text("Tell me a joke"))
  *     .tools(tool)
  *     .parameters(parameters)
  *     .build();
  * }</pre>
  */
 public class ChatRequest {
+    private final String deploymentId;
     private final List<ChatMessage> messages;
     private final List<Tool> tools;
     private final ChatParameters parameters;
     private final ExtractionTags extractionTags;
 
     protected ChatRequest(Builder builder) {
-        this.messages = requireNonNull(builder.messages, "messages cannot be null");
-        if (this.messages.isEmpty())
-            throw new RuntimeException("messages cannot be empty");
-        this.tools = builder.tools;
-        this.parameters = builder.parameters;
-        this.extractionTags = builder.extractionTags;
+        messages = requireNonNull(builder.messages, "messages cannot be null");
+        tools = builder.tools;
+        parameters = builder.parameters;
+        extractionTags = builder.extractionTags;
+        deploymentId = builder.deploymentId;
+    }
+
+    public String getDeploymentId() {
+        return deploymentId;
     }
 
     public List<ChatMessage> getMessages() {
@@ -99,8 +103,7 @@ public class ChatRequest {
      * ChatRequest request = ChatRequest.builder()
      *     .messages(
      *         SystemMessage.of("You are a helpful assistant"),
-     *         UserMessage.text("Tell me a joke")
-     *     )
+     *         UserMessage.text("Tell me a joke"))
      *     .tools(tool)
      *     .parameters(parameters)
      *     .build();
@@ -116,12 +119,25 @@ public class ChatRequest {
      * Builder class for constructing {@link ChatRequest} instances.
      */
     public static class Builder {
+        private String deploymentId;
         private List<ChatMessage> messages;
         private List<Tool> tools;
         private ChatParameters parameters;
         private ExtractionTags extractionTags;
 
         private Builder() {}
+
+        /**
+         * Sets the deployment identifier for the chat request.
+         * <p>
+         * This value is required if the request will be sent via a {@link DeploymentService}. For other services, this value may be ignored.
+         *
+         * @param deploymentId the unique identifier of the deployment
+         */
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
+            return this;
+        }
 
         /**
          * Sets the conversation messages for the request.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatService.java
@@ -18,10 +18,13 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscribers;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.ibm.watsonx.ai.WatsonxService.ModelService;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
@@ -29,6 +32,7 @@ import com.ibm.watsonx.ai.chat.model.ChatParameters.ToolChoice;
 import com.ibm.watsonx.ai.chat.model.ControlMessage;
 import com.ibm.watsonx.ai.chat.model.TextChatRequest;
 import com.ibm.watsonx.ai.chat.model.Tool;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.SseEventLogger;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 
@@ -57,6 +61,8 @@ import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
  */
 public final class ChatService extends ModelService implements ChatProvider {
 
+    public static final Logger logger = LoggerFactory.getLogger(ChatService.class);
+
     protected ChatService(Builder builder) {
         super(builder);
         requireNonNull(builder.getAuthenticationProvider(), "authenticationProvider cannot be null");
@@ -64,6 +70,10 @@ public final class ChatService extends ModelService implements ChatProvider {
 
     @Override
     public ChatResponse chat(ChatRequest chatRequest) {
+        requireNonNull(chatRequest, "chatRequest cannot be null");
+
+        if (nonNull(chatRequest.getDeploymentId()))
+            logger.info("The deploymentId parameter can not be used with the ChatService. Use the DeploymentService instead");
 
         List<ChatMessage> messages = chatRequest.getMessages();
         List<Tool> tools = nonNull(chatRequest.getTools()) && !chatRequest.getTools().isEmpty() ? chatRequest.getTools() : null;
@@ -121,7 +131,11 @@ public final class ChatService extends ModelService implements ChatProvider {
 
     @Override
     public CompletableFuture<Void> chatStreaming(ChatRequest chatRequest, ChatHandler handler) {
+        requireNonNull(chatRequest, "chatRequest cannot be null");
         requireNonNull(handler, "The chatHandler parameter can not be null");
+
+        if (nonNull(chatRequest.getDeploymentId()))
+            logger.info("The deploymentId parameter can not be used with the ChatService. Use the DeploymentService instead");
 
         var messages = chatRequest.getMessages();
         var tools = nonNull(chatRequest.getTools()) && !chatRequest.getTools().isEmpty() ? chatRequest.getTools() : null;
@@ -165,6 +179,187 @@ public final class ChatService extends ModelService implements ChatProvider {
             : BodySubscribers.fromLineSubscriber(subscriber))
             .thenAccept(r -> {})
             .exceptionally(t -> handlerError(t, handler));
+    }
+
+    /**
+     * Sends a chat request to the model using the provided message.
+     *
+     * @param message Message to send.
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(String message) {
+        return chat(UserMessage.text(message));
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(ChatMessage... messages) {
+        return chat(Arrays.asList(messages));
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+
+    public ChatResponse chat(List<ChatMessage> messages) {
+        return chat(messages, ChatParameters.builder().build());
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages and tools.
+     * <p>
+     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, include
+     * {@link Tool} definitions for function-calling models.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @param tools list of tools the model may call during generation
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(List<ChatMessage> messages, Tool... tools) {
+        return chat(messages, Arrays.asList(tools));
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages and tools.
+     * <p>
+     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, include
+     * {@link Tool} definitions for function-calling models.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @param tools list of tools the model may call during generation
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(List<ChatMessage> messages, List<Tool> tools) {
+        return chat(messages, null, tools);
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages, and parameters.
+     * <p>
+     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, and customize
+     * the generation behavior via {@link ChatParameters}.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @param parameters parameters to customize the output generation
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(List<ChatMessage> messages, ChatParameters parameters) {
+        return chat(messages, parameters, List.of());
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages, and parameters.
+     * <p>
+     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, and customize
+     * the generation behavior via {@link ChatParameters}.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @param parameters parameters to customize the output generation
+     * @param tools list of tools the model may call during generation
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(List<ChatMessage> messages, ChatParameters parameters, Tool... tools) {
+        return chat(messages, parameters, Arrays.asList(tools));
+    }
+
+    /**
+     * Sends a chat request to the model using the provided messages, and parameters.
+     * <p>
+     * This method performs a full chat completion call. It allows you to define the conversation history through {@link ChatMessage}s, and customize
+     * the generation behavior via {@link ChatParameters}.
+     *
+     * @param messages the list of chat messages representing the conversation history
+     * @param parameters parameters to customize the output generation
+     * @param tools list of tools the model may call during generation
+     * @return a {@link ChatResponse} object containing the model's reply
+     */
+    public ChatResponse chat(List<ChatMessage> messages, ChatParameters parameters, List<Tool> tools) {
+        return chat(
+            ChatRequest.builder()
+                .messages(messages)
+                .parameters(parameters)
+                .tools(tools)
+                .build()
+        );
+    }
+
+    /**
+     * Sends a chat request to the model using the provided message.
+     *
+     * @param message Message to send.
+     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
+     */
+    public CompletableFuture<Void> chatStreaming(String message, ChatHandler handler) {
+        return chatStreaming(List.of(UserMessage.text(message)), handler);
+    }
+
+    /**
+     * Sends a streaming chat request using the provided messages.
+     * <p>
+     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
+     * {@link ChatHandler}.
+     *
+     * @param messages the list of chat messages forming the prompt history
+     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
+     */
+    public CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, ChatHandler handler) {
+        return chatStreaming(messages, ChatParameters.builder().build(), handler);
+    }
+
+    /**
+     * Sends a streaming chat request using the provided messages.
+     * <p>
+     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
+     * {@link ChatHandler}.
+     *
+     * @param messages the list of chat messages forming the prompt history
+     * @param tools the list of tools that the model may use
+     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
+     */
+    public CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, List<Tool> tools, ChatHandler handler) {
+        return chatStreaming(messages, ChatParameters.builder().build(), tools, handler);
+    }
+
+    /**
+     * Sends a streaming chat request using the provided messages.
+     * <p>
+     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
+     * {@link ChatHandler}.
+     *
+     * @param messages the list of chat messages forming the prompt history
+     * @param parameters additional optional parameters for the chat invocation
+     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
+     */
+    public CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, ChatParameters parameters, ChatHandler handler) {
+        return chatStreaming(messages, parameters, null, handler);
+    }
+
+    /**
+     * Sends a streaming chat request using the provided messages.
+     * <p>
+     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
+     * {@link ChatHandler}.
+     *
+     * @param messages the list of chat messages forming the prompt history
+     * @param parameters additional optional parameters for the chat invocation
+     * @param tools the list of tools that the model may use
+     * @param handler a {@link ChatHandler} implementation that receives partial responses, the complete response, and error notifications
+     */
+    public CompletableFuture<Void> chatStreaming(List<ChatMessage> messages, ChatParameters parameters, List<Tool> tools,
+        ChatHandler handler) {
+        var chatRequest = ChatRequest.builder()
+            .messages(messages)
+            .parameters(parameters)
+            .tools(tools)
+            .build();
+        return chatStreaming(chatRequest, handler);
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/TextChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/TextChatRequest.java
@@ -229,6 +229,7 @@ public final class TextChatRequest {
             this.responseFormat = parameters.getResponseFormat();
             this.jsonSchema = parameters.getJsonSchema();
             this.context = parameters.getContext();
+            this.timeLimit = parameters.getTimeLimit();
             return this;
         }
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/deployment/FindByIdRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/deployment/FindByIdRequest.java
@@ -14,22 +14,23 @@ import com.ibm.watsonx.ai.WatsonxParameters;
  * <b>Example usage:</b>
  *
  * <pre>{@code
- * FindByIdParameters.builder()
+ * FindByIdRequest.builder()
+ *     .deploymentId("...")
  *     .spaceId("...")
  *     .build();
  * }</pre>
  *
  */
-public class FindByIdParameters extends WatsonxParameters {
-    private final String deployment;
+public class FindByIdRequest extends WatsonxParameters {
+    private final String deploymentId;
 
-    public FindByIdParameters(Builder builder) {
+    public FindByIdRequest(Builder builder) {
         super(builder);
-        deployment = builder.deployment;
+        deploymentId = builder.deploymentId;
     }
 
-    public String getDeployment() {
-        return deployment;
+    public String getDeploymentId() {
+        return deploymentId;
     }
 
     /**
@@ -38,7 +39,8 @@ public class FindByIdParameters extends WatsonxParameters {
      * <b>Example usage:</b>
      *
      * <pre>{@code
-     * FindByIdParameters.builder()
+     * FindByIdRequest.builder()
+     *     .deploymentId("...")
      *     .spaceId("...")
      *     .build();
      * }</pre>
@@ -50,20 +52,20 @@ public class FindByIdParameters extends WatsonxParameters {
     }
 
     /**
-     * Builder class for constructing {@link FindByIdParameters} instances.
+     * Builder class for constructing {@link FindByIdRequest} instances.
      */
     public static class Builder extends WatsonxParameters.Builder<Builder> {
-        private String deployment;
+        private String deploymentId;
 
         private Builder() {}
 
-        public Builder deployment(String deployment) {
-            this.deployment = deployment;
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
             return this;
         }
 
-        public FindByIdParameters build() {
-            return new FindByIdParameters(this);
+        public FindByIdRequest build() {
+            return new FindByIdRequest(this);
         }
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationProvider.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationProvider.java
@@ -25,73 +25,24 @@ import com.ibm.watsonx.ai.textgeneration.TextGenerationResponse.Result;
 public interface TextGenerationProvider {
 
     /**
-     * Generates text based on the given input string.
+     * Generates text based on the provided {@link TextGenerationRequest}.
      *
-     * @param input the input text to generate from
-     * @return a {@link TextGenerationResponse} containing the generated text and metadata
+     * @param request the {@link TextGenerationRequest} containing input, moderation, parameters.
+     * @return a {@link TextGenerationResponse} containing the generated text and associated metadata
      */
-    public default TextGenerationResponse generate(String input) {
-        return generate(input, null, null);
-    }
+    public TextGenerationResponse generate(TextGenerationRequest request);
 
     /**
-     * Generates text based on the given input string parameters.
-     *
-     * @param input the input text to generate from
-     * @param parameters the parameters to configure text generation behavior
-     * @return a {@link TextGenerationResponse} containing the generated text and metadata
-     */
-    public default TextGenerationResponse generate(String input, TextGenerationParameters parameters) {
-        return generate(input, null, parameters);
-    }
-
-    /**
-     * Generates text based on the given input string with moderation applied.
-     *
-     * @param input the input text to generate from
-     * @param moderation the moderation settings to apply during generation
-     * @return a {@link TextGenerationResponse} containing the generated text and metadata
-     */
-    public default TextGenerationResponse generate(String input, Moderation moderation) {
-        return generate(input, moderation, null);
-    }
-
-    /**
-     * Generates text based on the given input string, moderation and parameters.
-     *
-     * @param input the input text to generate from
-     * @param moderation the moderation settings to apply during generation
-     * @param parameters the parameters to configure text generation behavior
-     * @return a {@link TextGenerationResponse} containing the generated text and metadata
-     */
-    public TextGenerationResponse generate(String input, Moderation moderation, TextGenerationParameters parameters);
-
-    /**
-     * Sends a streaming text generation request using the provided messages
+     * Sends a streaming text generation request based on the provided {@link TextGenerationRequest}.
      * <p>
-     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
+     * This method initiates an asynchronous text generation operation where partial responses are delivered incrementally through the provided
      * {@link TextGenerationHandler}.
      *
-     * @param input the input prompt to send to the model
+     * @param request the {@link TextGenerationRequest} containing input, moderation, parameters, and optional deployment ID
      * @param handler the handler that will receive streamed generation events
-     * @return a {@link CompletableFuture} that completes when the generation is done
+     * @return a {@link CompletableFuture} that completes when the streaming generation is finished
      */
-    public default CompletableFuture<Void> generateStreaming(String input, TextGenerationHandler handler) {
-        return generateStreaming(input, null, handler);
-    }
-
-    /**
-     * Sends a streaming text generation request using the provided messages
-     * <p>
-     * This method initiates an asynchronous chat operation where partial responses are delivered incrementally through the provided
-     * {@link TextGenerationHandler}.
-     *
-     * @param input the input prompt to send to the model
-     * @param parameters the parameters to control the generation behavior
-     * @param handler the handler that will receive streamed generation events
-     * @return a {@link CompletableFuture} that completes when the generation is done
-     */
-    public CompletableFuture<Void> generateStreaming(String input, TextGenerationParameters parameters, TextGenerationHandler handler);
+    public CompletableFuture<Void> generateStreaming(TextGenerationRequest request, TextGenerationHandler handler);
 
     /**
      * Handles an error by invoking the {@link ChatHandler}'s {@code onError} callback if the given throwable is non-null.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationRequest.java
@@ -4,13 +4,145 @@
  */
 package com.ibm.watsonx.ai.textgeneration;
 
+import com.ibm.watsonx.ai.deployment.DeploymentService;
+
 /**
- * Represents a request for generating text using a specified model and input.
+ * Represents a text generation request.
+ * <p>
+ * Instances are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * var parameters = TextGenerationParameters.builder()
+ *     .decodingMethod("greedy")
+ *     .maxNewTokens(512)
+ *     .timeLimit(Duration.ofSeconds(10))
+ *     .build();
+ *
+ * TextGenerationRequest request = TextGenerationRequest.builder()
+ *     .input("Tell me a joke")
+ *     .parameters(parameters)
+ *     .build();
+ * }</pre>
  */
-public record TextGenerationRequest(
-    String modelId,
-    String spaceId,
-    String projectId,
-    String input,
-    TextGenerationParameters parameters,
-    Moderation moderations) {}
+public class TextGenerationRequest {
+    private final String deploymentId;
+    private final String input;
+    private final Moderation moderation;
+    private final TextGenerationParameters parameters;
+
+    protected TextGenerationRequest(Builder builder) {
+        input = builder.input;
+        moderation = builder.moderation;
+        parameters = builder.parameters;
+        deploymentId = builder.deploymentId;
+    }
+
+    public String getDeploymentId() {
+        return deploymentId;
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public Moderation getModeration() {
+        return moderation;
+    }
+
+    public TextGenerationParameters getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * var parameters = TextGenerationParameters.builder()
+     *     .decodingMethod("greedy")
+     *     .maxNewTokens(512)
+     *     .timeLimit(Duration.ofSeconds(10))
+     *     .build();
+     *
+     * TextGenerationRequest request = TextGenerationRequest.builder()
+     *     .input("Tell me a joke")
+     *     .parameters(parameters)
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link TextGenerationRequest} instances.
+     */
+    public static class Builder {
+        private String deploymentId;
+        private String input;
+        private Moderation moderation;
+        private TextGenerationParameters parameters;
+
+        private Builder() {}
+
+        /**
+         * Sets the deployment identifier for the text generation request.
+         * <p>
+         * This value is required if the request will be sent via a {@link DeploymentService}. For other services, this value may be ignored.
+         *
+         * @param deploymentId the unique identifier of the deployment
+         */
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
+            return this;
+        }
+
+        /**
+         * Sets the text input for the generation request.
+         * <p>
+         * This is the prompt that will be sent to the model for text generation.
+         *
+         * @param input the text prompt to generate from
+         */
+        public Builder input(String input) {
+            this.input = input;
+            return this;
+        }
+
+        /**
+         * Sets moderation options for the generation request.
+         * <p>
+         * The {@link Moderation} object can be used to apply content filtering or safety checks on the generated text.
+         *
+         * @param moderation a {@link Moderation} instance specifying moderation settings
+         */
+        public Builder moderation(Moderation moderation) {
+            this.moderation = moderation;
+            return this;
+        }
+
+        /**
+         * Sets the parameters controlling the text generation behavior.
+         *
+         * @param parameters a {@link TextGenerationParameters} instance
+         */
+        public Builder parameters(TextGenerationParameters parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
+        /**
+         * Builds a {@link TextGenerationRequest} instance using the configured parameters.
+         *
+         * @return a new instance of {@link TextGenerationRequest}
+         */
+        public TextGenerationRequest build() {
+            return new TextGenerationRequest(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextRequest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textgeneration;
+
+/**
+ * Represents a request for generating text using a specified model and input.
+ */
+public record TextRequest(
+    String modelId,
+    String spaceId,
+    String projectId,
+    String input,
+    TextGenerationParameters parameters,
+    Moderation moderations) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesProvider.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesProvider.java
@@ -15,23 +15,10 @@ import com.ibm.watsonx.ai.deployment.DeploymentService;
 public interface TimeSeriesProvider {
 
     /**
-     * Generates a forecast using the provided schema and data.
+     * Generates a forecast using the provided {@link TimeSeriesRequest}.
      *
-     * @param inputSchema the schema describing the time series
-     * @param data the historical data payload to use for prediction
+     * @param request a {@link TimeSeriesRequest} containing the input schema, data, and parameters
      * @return a {@link ForecastResponse} containing the forecasted time series values
      */
-    public default ForecastResponse forecast(InputSchema inputSchema, ForecastData data) {
-        return forecast(inputSchema, data, null);
-    }
-
-    /**
-     * Generates a forecast using the provided schema, data, and parameters.
-     *
-     * @param inputSchema the schema describing the time series
-     * @param data the historical data payload to use for prediction
-     * @param parameters additional forecasting configuration
-     * @return a {@link ForecastResponse} containing the forecasted time series values
-     */
-    public ForecastResponse forecast(InputSchema inputSchema, ForecastData data, TimeSeriesParameters parameters);
+    ForecastResponse forecast(TimeSeriesRequest request);
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesRequest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright IBM Corp. 2025 - 2025
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.timeseries;
+
+import static java.util.Objects.requireNonNull;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
+
+/**
+ * Represents a time series forecast request.
+ * <p>
+ * Instances are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * var inputSchema = InputSchema.builder()
+ *     .timestampColumn("date")
+ *     .addIdColumn("ID1")
+ *     .build();
+ *
+ * var data = ForecastData.create()
+ *     .add("date", "2020-01-01T00:00:00")
+ *     .add("date", "2020-01-01T01:00:00")
+ *     .add("date", "2020-01-05T01:00:00")
+ *     .add("ID1", "D1", 3)
+ *     .addAll("TARGET1", 1.46, 2.34, 4.55);
+ *
+ * TimeSeriesRequest request = TimeSeriesRequest.builder()
+ *     .inputSchema(inputSchema)
+ *     .data(data)
+ *     .build();
+ * }</pre>
+ */
+public class TimeSeriesRequest {
+    private String deploymentId;
+    private InputSchema inputSchema;
+    private ForecastData data;
+    private TimeSeriesParameters parameters;
+
+    protected TimeSeriesRequest(Builder builder) {
+        inputSchema = requireNonNull(builder.inputSchema, "InputSchema cannot be null");
+        data = requireNonNull(builder.data, "Data cannot be null");
+        parameters = builder.parameters;
+        deploymentId = builder.deploymentId;
+    }
+
+    public String getDeploymentId() {
+        return deploymentId;
+    }
+
+    public InputSchema getInputSchema() {
+        return inputSchema;
+    }
+
+    public ForecastData getData() {
+        return data;
+    }
+
+    public TimeSeriesParameters getParameters() {
+        return parameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link TimeSeriesRequest} instances.
+     */
+    public static class Builder {
+        private String deploymentId;
+        private InputSchema inputSchema;
+        private ForecastData data;
+        private TimeSeriesParameters parameters;
+
+        private Builder() {}
+
+        /**
+         * Sets the deployment identifier for the time series request.
+         * <p>
+         * This value is required if the request will be sent via a {@link DeploymentService}. For other services, this value may be ignored.
+         *
+         * @param deploymentId the unique identifier of the deployment
+         */
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
+            return this;
+        }
+
+        /**
+         * Sets the input schema for the time series request.
+         * <p>
+         * The {@link InputSchema} defines the timestamp column and any identifier columns for the time series. This is required for the service to
+         * understand the structure of the provided data.
+         *
+         * @param inputSchema the {@link InputSchema} instance
+         */
+        public Builder inputSchema(InputSchema inputSchema) {
+            this.inputSchema = inputSchema;
+            return this;
+        }
+
+        /**
+         * Sets the actual data for the time series forecast request.
+         * <p>
+         * The {@link ForecastData} contains all the timestamped records and target values that the service will use for forecasting.
+         *
+         * @param data the {@link ForecastData} instance
+         */
+        public Builder data(ForecastData data) {
+            this.data = data;
+            return this;
+        }
+
+        /**
+         * Sets the parameters controlling the time series forecast behavior.
+         *
+         * @param parameters a {@link TimeSeriesParameters} instance
+         */
+        public Builder parameters(TimeSeriesParameters parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
+        /**
+         * Builds a {@link TimeSeriesRequest} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ChatReTimeSeriesRequestquest}
+         */
+        public TimeSeriesRequest build() {
+            return new TimeSeriesRequest(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TextGenerationServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/TextGenerationServiceTest.java
@@ -59,6 +59,7 @@ import com.ibm.watsonx.ai.textgeneration.TextGenerationResponse.Result;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationResponse.TokenInfo;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationResponse.TopTokenInfo;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationService;
+import com.ibm.watsonx.ai.textgeneration.TextRequest;
 import com.ibm.watsonx.ai.utils.Utils;
 
 @SuppressWarnings("unchecked")
@@ -344,7 +345,7 @@ public class TextGenerationServiceTest extends AbstractWatsonxTest {
             var response = textGenerationService.generate("Hello!");
             assertNotNull(response);
 
-            var expected = new TextGenerationRequest("model", "space-id", "project-id", "Hello!",
+            var expected = new TextRequest("model", "space-id", "project-id", "Hello!",
                 TextGenerationParameters.builder().timeLimit(Duration.ofSeconds(1)).build(), null);
 
             JSONAssert.assertEquals(Json.toJson(expected), Utils.bodyPublisherToString(mockHttpRequest), true);
@@ -358,7 +359,7 @@ public class TextGenerationServiceTest extends AbstractWatsonxTest {
                 .promptVariables(Map.of("test", "test")) // this field must be ignored
                 .build());
 
-            expected = new TextGenerationRequest("new-model", "new-space-id", "new-project-id", "Hello!",
+            expected = new TextRequest("new-model", "new-space-id", "new-project-id", "Hello!",
                 TextGenerationParameters.builder().timeLimit(Duration.ofSeconds(2)).build(), null);
 
             JSONAssert.assertEquals(Json.toJson(expected), Utils.bodyPublisherToString(mockHttpRequest), false);
@@ -395,7 +396,7 @@ public class TextGenerationServiceTest extends AbstractWatsonxTest {
             var response = textGenerationService.generate("Hello!", moderation);
             assertNotNull(response);
 
-            var expected = new TextGenerationRequest("model", "space-id", "project-id", "Hello!",
+            var expected = new TextRequest("model", "space-id", "project-id", "Hello!",
                 TextGenerationParameters.builder().timeLimit(Duration.ofSeconds(1)).build(), moderation);
 
             JSONAssert.assertEquals(Json.toJson(expected), Utils.bodyPublisherToString(mockHttpRequest), true);
@@ -414,11 +415,8 @@ public class TextGenerationServiceTest extends AbstractWatsonxTest {
             .url(CloudRegion.DALLAS)
             .build();
 
-        var ex = assertThrows(IllegalArgumentException.class, () -> textGenerationService.generate(null));
-        assertEquals(ex.getMessage(), "The input can not be null or empty");
-
-        ex = assertThrows(IllegalArgumentException.class, () -> textGenerationService.generate(""));
-        assertEquals(ex.getMessage(), "The input can not be null or empty");
+        var ex = assertThrows(NullPointerException.class, () -> textGenerationService.generate(TextGenerationRequest.builder().build()));
+        assertEquals(ex.getMessage(), "input cannot be null");
 
         when(mockHttpClient.send(mockHttpRequest.capture(), any(BodyHandler.class)))
             .thenThrow(IOException.class);

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ChatServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ChatServiceTest.java
@@ -283,8 +283,6 @@ public class ChatServiceTest extends AbstractWatsonxTest {
     @Test
     void text_chat() throws Exception {
 
-        assertThrows(RuntimeException.class, () -> ChatRequest.builder().messages(List.of()).build(), "messages cannot be empty");
-
         final String REQUEST = """
             {
               "model_id": "meta-llama/llama-3-8b-instruct",

--- a/samples/deployment/src/main/java/com/ibm/deployment/App.java
+++ b/samples/deployment/src/main/java/com/ibm/deployment/App.java
@@ -8,11 +8,12 @@ import java.net.URI;
 import java.time.Duration;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import com.ibm.watsonx.ai.chat.ChatRequest;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
-import com.ibm.watsonx.ai.deployment.FindByIdParameters;
+import com.ibm.watsonx.ai.deployment.FindByIdRequest;
 
 public class App {
 
@@ -33,14 +34,13 @@ public class App {
 
             DeploymentService deploymentService = DeploymentService.builder()
                 .authenticationProvider(authProvider)
-                .timeout(Duration.ofSeconds(60))
-                .deployment(deployment)
                 .url(url)
                 .build();
 
             var deploymentInfo = deploymentService.findById(
-                FindByIdParameters.builder()
+                FindByIdRequest.builder()
                     .spaceId(spaceId)
+                    .deploymentId(deployment)
                     .build()
             );
 
@@ -53,11 +53,16 @@ public class App {
                 deploymentInfo.metadata().name(), deploymentInfo.entity().deployedAssetType(), deploymentInfo.entity().status().state()));
 
             var message = "How are you?";
+            var chatRequest = ChatRequest.builder()
+                .deploymentId(deployment)
+                .messages(UserMessage.text(message))
+                .build();
+
             System.out.println("USER: ".concat(message));
-            System.out.println("ASSISTANT: ".concat(deploymentService.chat(UserMessage.text(message)).extractContent()));
+            System.out.println("ASSISTANT: ".concat(deploymentService.chat(chatRequest).extractContent()));
 
         } catch (Exception e) {
-            e.printStackTrace();
+            // e.printStackTrace();
         } finally {
             System.exit(0);
         }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.ibm.watsonx</groupId>
       <artifactId>watsonx-ai</artifactId>
-      <version>0.8.0</version>
+      <version>999-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/samples/time-series/src/main/java/com/ibm/timeseries/App.java
+++ b/samples/time-series/src/main/java/com/ibm/timeseries/App.java
@@ -41,9 +41,10 @@ public class App {
             TimeSeriesService tsService = TimeSeriesService.builder()
                 .authenticationProvider(authProvider)
                 .projectId(projectId)
-                .timeout(Duration.ofSeconds(60))
                 .url(url)
                 .modelId("ibm/granite-ttm-512-96-r2")
+                .logRequests(true)
+                .logResponses(true)
                 .build();
 
             var inputSchema = InputSchema.builder()


### PR DESCRIPTION
- Removed default methods from `ChatProvider` interface and moved their implementations into `ChatService`
- Replaced multiple parameter-based methods with unified request objects (`TextGenerationRequest`, `TimeSeriesRequest`) in provider interfaces
- Rename `FindByIdParameters` in `FindByIdRequest` class
- Updated `DeploymentService` to use request-based parameters
- Streamlined method signatures across services to consistently use request objects