### PR TITLE
Add API key authentication convenience method to WatsonxService builder

### DIFF
--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.concurrent.Executor;
 import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
+import com.ibm.watsonx.ai.core.auth.iam.IAMAuthenticator;
 import com.ibm.watsonx.ai.core.http.AsyncHttpClient;
 import com.ibm.watsonx.ai.core.http.SyncHttpClient;
 import com.ibm.watsonx.ai.core.http.interceptors.BearerInterceptor;
@@ -172,9 +173,26 @@ public abstract class WatsonxService {
         }
 
         /**
-         * Sets the {@link AuthenticationProvider} used for authenticating requests.
+         * Sets an {@link IAMAuthenticator}-based {@link AuthenticationProvider}, initialized from the provided IBM Cloud API key.
+         * <p>
+         * For alternative authentication mechanisms, use {@link #authenticationProvider(AuthenticationProvider)}.
          *
-         * @param authenticationProvider {@link AuthenticationProvider} instance
+         * @param apiKey IBM Cloud API key
+         */
+        public T apiKey(String apiKey) {
+            requireNonNull(apiKey, "The apiKey must be provided");
+            authenticationProvider = IAMAuthenticator.builder().apiKey(apiKey).build();
+            return (T) this;
+        }
+
+        /**
+         * Sets the {@link AuthenticationProvider} used to authenticate requests.
+         * <p>
+         * Use this method to specify a custom or non-IAM implementation.
+         * <p>
+         * For IBM Cloud IAM authentication, {@link #apiKey(String)} provides a simpler alternative.
+         *
+         * @param authenticationProvider non-null {@link AuthenticationProvider} instance
          */
         public T authenticationProvider(AuthenticationProvider authenticationProvider) {
             this.authenticationProvider = authenticationProvider;

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatService.java
@@ -37,14 +37,14 @@ import com.ibm.watsonx.ai.core.SseEventLogger;
 import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
 
 /**
- * Service class to interact with IBM watsonx.ai Text Chat APIs.
+ * Service for interacting with IBM watsonx.ai Text Chat APIs.
  * <p>
  * <b>Example usage:</b>
  *
  * <pre>{@code
  * ChatService chatService = ChatService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .projectId("my-project-id")
  *     .modelId("ibm/granite-3-8b-instruct")
  *     .build();
@@ -55,7 +55,7 @@ import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
  * );
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-chat" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -369,8 +369,8 @@ public final class ChatService extends ModelService implements ChatProvider {
      *
      * <pre>{@code
      * ChatService chatService = ChatService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .projectId("my-project-id")
      *     .modelId("ibm/granite-3-8b-instruct")
      *     .build();
@@ -381,7 +381,6 @@ public final class ChatService extends ModelService implements ChatProvider {
      * );
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/deployment/DeploymentService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/deployment/DeploymentService.java
@@ -53,13 +53,13 @@ import com.ibm.watsonx.ai.timeseries.TimeSeriesRequest;
  *
  * <pre>{@code
  * DeploymentService deploymentService = DeploymentService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .build();
  *
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#deployments-text-chat" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}. *
  *
  * @see AuthenticationProvider
  */
@@ -332,17 +332,11 @@ public class DeploymentService extends WatsonxService implements ChatProvider, T
      *
      * <pre>{@code
      * DeploymentService deploymentService = DeploymentService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .deployment("...")
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .build();
-     *
-     * ChatResponse response = deploymentService.chat(
-     *     UserMessage.text("Tell me a joke")
-     * );
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/embedding/EmbeddingService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/embedding/EmbeddingService.java
@@ -29,8 +29,8 @@ import com.ibm.watsonx.ai.embedding.EmbeddingRequest.Parameters;
  *
  * <pre>{@code
  * EmbeddingService embeddingService = EmbeddingService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .projectId("my-project-id")
  *     .modelId("ibm/granite-embedding-278m-multilingual")
  *     .build();
@@ -41,7 +41,7 @@ import com.ibm.watsonx.ai.embedding.EmbeddingRequest.Parameters;
  * );
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -144,8 +144,8 @@ public final class EmbeddingService extends ModelService {
      *
      * <pre>{@code
      * EmbeddingService embeddingService = EmbeddingService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .projectId("my-project-id")
      *     .modelId("ibm/granite-embedding-278m-multilingual")
      *     .build();
@@ -156,7 +156,6 @@ public final class EmbeddingService extends ModelService {
      * );
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/foundationmodel/FoundationModelService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/foundationmodel/FoundationModelService.java
@@ -36,9 +36,6 @@ import com.ibm.watsonx.ai.foundationmodel.filter.Filter;
  * var maxSequenceLength = result.maxSequenceLength();
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#list-foundation-model-specs" target="_blank"> official
- * documentation</a>.
- *
  * @see AuthenticationProvider
  */
 public final class FoundationModelService extends WatsonxService {
@@ -222,7 +219,6 @@ public final class FoundationModelService extends WatsonxService {
      * var maxSequenceLength = result.maxSequenceLength();
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/rerank/RerankService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/rerank/RerankService.java
@@ -29,8 +29,8 @@ import com.ibm.watsonx.ai.rerank.RerankRequest.RerankInput;
  *
  * <pre>{@code
  * RerankService rerankService = RerankService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .projectId("my-project-id")
  *     .modelId("cross-encoder/ms-marco-minilm-l-12-v2")
  *     .build();
@@ -44,7 +44,7 @@ import com.ibm.watsonx.ai.rerank.RerankRequest.RerankInput;
  * );
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-rerank" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -128,8 +128,8 @@ public final class RerankService extends ModelService {
      *
      * <pre>{@code
      * RerankService rerankService = RerankService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .projectId("my-project-id")
      *     .modelId("cross-encoder/ms-marco-minilm-l-12-v2")
      *     .build();
@@ -143,7 +143,6 @@ public final class RerankService extends ModelService {
      * );
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textextraction/TextExtractionService.java
@@ -51,9 +51,9 @@ import com.ibm.watsonx.ai.textextraction.TextExtractionResponse.Status;
  *
  * <pre>{@code
  * TextExtractionService textExtractionService = TextExtractionService.builder()
- *   .url("https://...") // or use CloudRegion
- *   .cosUrl("https://...") // or use CosUrl
- *   .authenticationProvider(authProvider)
+ *   .url("https://...")        // or use CloudRegion
+ *   .cosUrl("https://...")     // or use CosUrl
+ *   .apiKey("my-api-key")      // creates an IAM-based AuthenticationProvider
  *   .projectId("my-project-id")
  *   .documentReference("<connection_id>", "<bucket-name")
  *   .resultReference("<connection_id>", "<bucket-name")
@@ -62,7 +62,7 @@ import com.ibm.watsonx.ai.textextraction.TextExtractionResponse.Status;
  * TextExtractionResponse response = textExtractionService.startExtraction("myfile.pdf")
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-extraction" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -824,9 +824,9 @@ public final class TextExtractionService extends ProjectService {
      *
      * <pre>{@code
      * TextExtractionService textExtractionService = TextExtractionService.builder()
-     *   .url("https://...") // or use CloudRegion
-     *   .cosUrl("https://...") // or use CosUrl
-     *   .authenticationProvider(authProvider)
+     *   .url("https://...")        // or use CloudRegion
+     *   .cosUrl("https://...")     // or use CosUrl
+     *   .apiKey("my-api-key")      // creates an IAM-based AuthenticationProvider
      *   .projectId("my-project-id")
      *   .documentReference("<connection_id>", "<bucket-name")
      *   .resultReference("<connection_id>", "<bucket-name")
@@ -835,7 +835,6 @@ public final class TextExtractionService extends ProjectService {
      * TextExtractionResponse response = textExtractionService.startExtraction("myfile.pdf")
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textgeneration/TextGenerationService.java
@@ -32,8 +32,8 @@ import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
  *
  * <pre>{@code
  * TextGenerationService textGenerationService = TextGenerationService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .projectId("my-project-id")
  *     .modelId("ibm/granite-13b-instruct-v2")
  *     .build();
@@ -41,7 +41,7 @@ import com.ibm.watsonx.ai.core.auth.AuthenticationProvider;
  * TextGenerationResponse response = textGenerationService.generate("Hello!");
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-generation" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -223,8 +223,8 @@ public final class TextGenerationService extends ModelService implements TextGen
      *
      * <pre>{@code
      * TextGenerationService textGenerationService = TextGenerationService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .projectId("my-project-id")
      *     .modelId("ibm/granite-13b-instruct-v2")
      *     .build();
@@ -232,7 +232,6 @@ public final class TextGenerationService extends ModelService implements TextGen
      * TextGenerationResponse response = textGenerationService.generate("Hello!");
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/timeseries/TimeSeriesService.java
@@ -28,8 +28,8 @@ import com.ibm.watsonx.ai.timeseries.ForecastRequest.Parameters;
  *
  * <pre>{@code
  * TimeSeriesService tsService = TimeSeriesService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .projectId("my-project-id")
  *     .modelId("ibm/granite-ttm-1536-96-r2")
  *     .build();
@@ -54,7 +54,7 @@ import com.ibm.watsonx.ai.timeseries.ForecastRequest.Parameters;
  * ForecastResponse response = tsService.forecast(request);
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#time-series-forecast" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -149,8 +149,8 @@ public final class TimeSeriesService extends ModelService implements TimeSeriesP
      *
      * <pre>{@code
      * TimeSeriesService tsService = TimeSeriesService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .projectId("my-project-id")
      *     .modelId("ibm/granite-ttm-1536-96-r2")
      *     .build();
@@ -175,7 +175,6 @@ public final class TimeSeriesService extends ModelService implements TimeSeriesP
      * ForecastResponse response = tsService.forecast(request);
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tokenization/TokenizationService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tokenization/TokenizationService.java
@@ -28,8 +28,8 @@ import com.ibm.watsonx.ai.tokenization.TokenizationRequest.Parameters;
  *
  * <pre>{@code
  * TokenizationService tokenizationService = TokenizationService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")      // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
  *     .projectId("my-project-id")
  *     .modelId("ibm/granite-3-8b-instruct")
  *     .build();
@@ -37,7 +37,7 @@ import com.ibm.watsonx.ai.tokenization.TokenizationRequest.Parameters;
  * TokenizationResponse response = tokenizationService.tokenize("Tell me a joke");
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-tokenization" target="_blank"> official documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see AuthenticationProvider
  */
@@ -148,8 +148,8 @@ public final class TokenizationService extends ModelService {
      *
      * <pre>{@code
      * TokenizationService tokenizationService = TokenizationService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")      // or use CloudRegion
+     *     .apiKey("my-api-key")    // creates an IAM-based AuthenticationProvider
      *     .projectId("my-project-id")
      *     .modelId("ibm/granite-3-8b-instruct")
      *     .build();
@@ -157,7 +157,6 @@ public final class TokenizationService extends ModelService {
      * TokenizationResponse response = tokenizationService.tokenize("Tell me a joke");
      * }</pre>
      *
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tool/ToolService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/tool/ToolService.java
@@ -36,8 +36,8 @@ import com.ibm.watsonx.ai.tool.builtin.WikipediaTool;
  *
  * <pre>{@code
  * ToolService service = ToolService.builder()
- *     .url("https://...") // or use CloudRegion
- *     .authenticationProvider(authProvider)
+ *     .url("https://...")  // or use CloudRegion
+ *     .apiKey("api-key")   // creates an IAM-based AuthenticationProvider
  *     .build();
  *
  * var structuredInput = Map.<String, Object>of("q", input);
@@ -46,8 +46,7 @@ import com.ibm.watsonx.ai.tool.builtin.WikipediaTool;
  * var result = toolService.run(input);
  * }</pre>
  *
- * For more information, see the <a href="https://cloud.ibm.com/apidocs/watsonx-ai#get-utility-agent-tools" target="_blank">official
- * documentation</a>.
+ * To use a custom authentication mechanism, configure it explicitly with {@link #authenticationProvider(AuthenticationProvider)}.
  *
  * @see GoogleSearchTool
  * @see TavilySearchTool
@@ -198,16 +197,20 @@ public final class ToolService extends WatsonxService {
      *
      * <pre>{@code
      * ToolService service = ToolService.builder()
-     *     .url("https://...") // or use CloudRegion
-     *     .authenticationProvider(authProvider)
+     *     .url("https://...")  // or use CloudRegion
+     *     .apiKey("api-key")   // creates an IAM-based AuthenticationProvider
      *     .build();
+     *
+     * var structuredInput = Map.<String, Object>of("q", input);
+     * var config = Map.<String, Object>of("maxResults", maxResults);
+     * var input = ToolRequest.structuredInput("GoogleSearch", structuredInput, config);
+     * var result = toolService.run(input);
      * }</pre>
      *
      * @see GoogleSearchTool
      * @see WeatherTool
      * @see WebCrawlerTool
      * @see WikipediaTool
-     * @see AuthenticationProvider
      * @return {@link Builder} instance.
      */
     public static Builder builder() {

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ChatServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ChatServiceIT.java
@@ -72,9 +72,9 @@ public class ChatServiceIT {
 
             var chatService = ChatService.builder()
                 .url(URL)
+                .apiKey(API_KEY)
                 .projectId(PROJECT_ID)
                 .modelId("ibm/granite-3-3-8b-instruct")
-                .authenticationProvider(authentication)
                 .logRequests(true)
                 .logResponses(true)
                 .build();


### PR DESCRIPTION
Introduced a new `apiKey(String apiKey)` method in the `WatsonxService.Builder` class to simplify IAM authentication setup. This method internally creates an `IAMAuthenticator` instance using the provided IBM Cloud API key