### PR TITLE
Chat inline moderation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before getting started, ensure you have:
 - Java 17 or higher
 - Maven or Gradle
 
-New to watsonx.ai? The [Setup & Prerequisites](https://ibm.github.io/watsonx-ai-java-sdk/setup) guide walks through creating the resources the SDK needs (API key, Project ID, Cloud Object Storage, and more), with links to the IBM documentation.
+The [Setup & Prerequisites](https://ibm.github.io/watsonx-ai-java-sdk/setup) guide walks through creating the resources the SDK needs (API key, Project ID, Cloud Object Storage, and more), with links to the IBM documentation.
 
 ## Installation
 

--- a/docs/services/chat-service.md
+++ b/docs/services/chat-service.md
@@ -766,6 +766,141 @@ ChatService limitedService = ChatService.builder()
 
 ---
 
+## Content Moderation
+
+Content moderation lets watsonx.ai screen chat input and output for **Personally Identifiable Information (PII)**, **Hate and Profanity (HAP)**, and **Granite Guardian** categories. When one or more detectors match, the results are returned alongside the assistant's response so your application can decide how to react - redact, block, log, warn the user - based on your own policy.
+
+> **Two modes are available for content screening in the SDK:**
+> - **Inline chat moderation** (this section) - attach a `ChatModeration` to a `ChatRequest`. Detectors run as part of the chat call and results come back on the `ChatResponse`. Use it when you want screening to happen *during* the generation.
+> - **Standalone detection** via [`DetectionService`]({{ site.baseurl }}/services/detection-service/) - analyze arbitrary text with `Hap`, `Pii`, and `GraniteGuardian` outside a chat flow (e.g. moderating user-generated content, log analysis, offline scans).
+>
+> The two APIs are independent: the same detector categories but different request types (`ChatRequest` vs `DetectionTextRequest`), different response shapes, and different classes (`com.ibm.watsonx.ai.chat.ChatModeration.*` vs `com.ibm.watsonx.ai.detection.detector.*`).
+
+### Detector Types
+
+| Detector | Purpose | Enable via |
+|---|---|---|
+| `pii` | Detects personal data such as phone numbers, emails, credit cards, addresses | `.pii(p -> p.input(true).output(true))` |
+| `hap` | Detects hate and profanity above a confidence threshold | `.hap(h -> h.input(0.8f).output(0.9f))` |
+| `graniteGuardian` | General-purpose harm/safety classifier | `.graniteGuardian(g -> g.input(0.85f))` |
+
+Each detector accepts an `input` toggle/threshold, an `output` toggle/threshold, and an optional `.mask(true)` flag.
+
+### Enabling Moderation on a Request
+
+Attach a `ChatModeration` configuration to a `ChatRequest` via `.moderations(...)`:
+
+```java
+var moderation = ChatModeration.builder()
+    .pii(p -> p.output(true))
+    .hap(h -> h.output(0.8f))
+    .build();
+
+var request = ChatRequest.builder()
+    .messages(
+        SystemMessage.of("You are a helpful assistant"),
+        UserMessage.text("Contact me at john@example.com, phone 555-1234"))
+    .moderations(moderation)
+    .build();
+
+ChatResponse response = chatService.chat(request);
+```
+
+### Reading the Results
+
+When one or more detectors match, `ChatResponse` exposes two independent structures:
+
+- `response.moderations()` - a map keyed by detector name (`"pii"`, `"hap"`, `"granite_guardian"`) with per-match details (`score`, `input`, `position`, `entity`, `word`).
+- `response.detections()` - a map keyed by target position (`"input"`, `"output"`) with per-choice detection entries containing the underlying detector ID and matches.
+
+Both are `null` when no detector matched.
+
+```java
+if (response.moderations() != null) {
+    var piiMatches = response.moderations().get("pii");
+    if (piiMatches != null) {
+        for (var match : piiMatches) {
+            System.out.printf("%s: %s (score=%.2f, at [%d, %d))%n",
+                match.entity(), match.word(), match.score(),
+                match.position().start(), match.position().end());
+        }
+    }
+}
+```
+
+Fields on `ModerationResult`:
+
+| Field | Type | Description |
+|---|---|---|
+| `score` | `float` | Confidence of the match (0.0 – 1.0) |
+| `input` | `boolean` | `true` if the match was found in the input, `false` for output |
+| `position` | `Position` | Start (inclusive) / end (exclusive) offsets in the text |
+| `entity` | `String` | Detected entity type (e.g. `"PhoneNumber"`) |
+| `word` | `String` | The matched text |
+
+### Restricting Moderation to Input Ranges
+
+You can limit input moderation to specific text ranges via `InputRanges`:
+
+```java
+var moderation = ChatModeration.builder()
+    .pii(p -> p.input(true))
+    .inputRanges(List.of(
+        InputRanges.of(0, 50),
+        InputRanges.of(100, 150)))
+    .build();
+```
+
+Only text within the given ranges is evaluated on input.
+
+### Redacting Content
+
+The SDK returns detection results untouched - it does **not** modify the assistant message content. When you want to redact matched values, use the `Masker` utility class, which walks through the output moderation matches and rewrites the corresponding ranges:
+
+```java
+var content = response.toAssistantMessage().content();
+
+// Default: replace each matched range with '*' of the same length.
+String masked = Masker.mask(content, response);
+
+// Custom: replace each match with a labelled placeholder.
+String labelled = Masker.mask(content, response, m -> "[" + m.entity() + "]");
+```
+
+Pass a custom replacer when you need a redaction policy that depends on more than the single match (e.g. hashing, tokenization, external lookup).
+
+### Streaming
+
+Moderation is fully supported in streaming mode. Results are available in two places:
+
+- **Per-chunk** on `PartialChatResponse.moderations()` and `.detections()` inside `onPartialResponse` - the same shape as the final response, scoped to what was flagged in that single chunk. Empty when the chunk carries no match. Useful to react in real time (stop the stream, tag the current token, alert an auditor).
+- **Aggregated** on the final `ChatResponse` passed to `onCompleteResponse` - all per-chunk matches merged. Detection entries with the same `choice_index` are collapsed into a single entry.
+
+```java
+chatService.chatStreaming(request, new ChatHandler() {
+    @Override
+    public void onPartialResponse(String chunk, PartialChatResponse partial) {
+        System.out.print(chunk);
+
+        // Per-chunk reaction: this chunk triggered one or more detectors.
+        if (partial.moderations() != null && !partial.moderations().isEmpty()) {
+            partial.moderations().forEach((detector, matches) ->
+                System.out.printf("%n[%s] flagged in this chunk: %d match(es)%n", detector, matches.size()));
+        }
+    }
+
+    @Override
+    public void onCompleteResponse(ChatResponse response) {
+        // Aggregated view across the whole stream.
+        if (response.moderations() != null) {
+            System.out.println("\nModeration results (aggregated): " + response.moderations().keySet());
+        }
+    }
+});
+```
+
+---
+
 ## Related Resources
 
 - [Chat API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#chat-completions)
@@ -775,3 +910,4 @@ ChatService limitedService = ChatService.builder()
 - [Chatbot with Tools (Sample)](https://github.com/IBM/watsonx-ai-java-sdk/tree/main/samples/chatbot-tools)
 - [Chatbot with ToolRegistry (Sample)](https://github.com/IBM/watsonx-ai-java-sdk/tree/main/samples/chatbot-with-tool-registry)
 - [Chatbot with Reasoning (Sample)](https://github.com/IBM/watsonx-ai-java-sdk/tree/main/samples/chatbot-reasoning)
+- [Chat Inline Moderation (Sample)](https://github.com/IBM/watsonx-ai-java-sdk/tree/main/samples/chat-inline-moderation)

--- a/docs/services/detection-service.md
+++ b/docs/services/detection-service.md
@@ -42,6 +42,12 @@ The `DetectionService` enables you to:
 - Combine multiple detectors in a single request.
 - Configure detection thresholds for fine-grained control.
 
+> **Two modes are available for content screening in the SDK:**
+> - **Standalone detection** (this service) - analyze arbitrary text with `Hap`, `Pii`, and `GraniteGuardian` outside a chat flow (e.g. moderating user-generated content, log analysis, offline scans).
+> - **Inline chat moderation** via [`ChatService`]({{ site.baseurl }}/services/chat-service/#content-moderation) - attach a `ChatModeration` to a `ChatRequest` and let detectors run *during* the chat call. Results come back on the `ChatResponse`.
+>
+> The two APIs are independent: the same detector categories but different request types (`DetectionTextRequest` vs `ChatRequest`), different response shapes, and different classes (`com.ibm.watsonx.ai.detection.detector.*` vs `com.ibm.watsonx.ai.chat.ChatModeration.*`).
+
 ---
 
 ## Service Configuration

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxJacksonModule.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxJacksonModule.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.ibm.watsonx.ai.batch.BatchCreateRequest;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
@@ -81,6 +82,11 @@ public class WatsonxJacksonModule extends SimpleModule {
         setMixInAnnotation(TextGenerationParameters.Builder.class, TextGenerationParametersBuilderMixin.class);
         setMixInAnnotation(Moderation.class, ModerationMixin.class);
         setMixInAnnotation(Moderation.Builder.class, ModerationBuilderMixin.class);
+
+        // --- Chat Moderation Mixin --- //
+        setMixInAnnotation(com.ibm.watsonx.ai.chat.ChatModeration.class, ChatModerationMixin.class);
+        setMixInAnnotation(ChatResponse.DetectionEntry.class, ChatResponseDetectionEntryMixin.class);
+        setMixInAnnotation(ChatResponse.DetectionResult.class, ChatResponseDetectionResultMixin.class);
 
         // --- Schema Mixin --- //
         setMixInAnnotation(ArraySchema.class, ArraySchemaMixin.class);
@@ -151,6 +157,21 @@ public class WatsonxJacksonModule extends SimpleModule {
 
     @JsonPOJOBuilder(withPrefix = "")
     public abstract static class ModerationBuilderMixin {}
+
+    public abstract static class ChatModerationMixin {
+
+        @JsonProperty("hap")
+        abstract ChatModeration.Hap hap();
+
+        @JsonProperty("pii")
+        abstract ChatModeration.Pii pii();
+
+        @JsonProperty("granite_guardian")
+        abstract ChatModeration.GraniteGuardian graniteGuardian();
+
+        @JsonProperty("input_ranges")
+        abstract List<ChatModeration.InputRanges> inputRanges();
+    }
 
     @JsonDeserialize(builder = TextGenerationParameters.Builder.class)
     public abstract static class TextGenerationParametersMixin {
@@ -322,6 +343,31 @@ public class WatsonxJacksonModule extends SimpleModule {
 
         @JsonProperty("extraction_tags")
         abstract ExtractionTags extractionTags();
+
+        @JsonProperty("moderations")
+        abstract Map<String, List<ChatResponse.ModerationResult>> moderations();
+
+        @JsonProperty("detections")
+        abstract Map<String, List<ChatResponse.DetectionEntry>> detections();
+    }
+
+    public abstract static class ChatResponseDetectionEntryMixin {
+        @JsonCreator
+        public ChatResponseDetectionEntryMixin(
+            @JsonProperty("choice_index") int choiceIndex,
+            @JsonProperty("results") List<ChatResponse.DetectionResult> results) {}
+    }
+
+    public abstract static class ChatResponseDetectionResultMixin {
+        @JsonCreator
+        public ChatResponseDetectionResultMixin(
+            @JsonProperty("detector_id") String detectorId,
+            @JsonProperty("detection_type") String detectionType,
+            @JsonProperty("detection") String detection,
+            @JsonProperty("score") double score,
+            @JsonProperty("text") String text,
+            @JsonProperty("start") int start,
+            @JsonProperty("end") int end) {}
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -422,6 +468,9 @@ public class WatsonxJacksonModule extends SimpleModule {
 
         @JsonProperty("json_schema")
         abstract JsonSchemaObject jsonSchema();
+
+        @JsonProperty("moderations")
+        abstract ChatModeration moderations();
 
         @JsonProperty("crypto")
         abstract Map<String, Object> crypto();

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatModeration.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatModeration.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import static java.util.Objects.isNull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Container class for different moderation configurations used in a chat request.
+ * <p>
+ * Supports various moderation types such as Hate and Profanity (HAP), Personally Identifiable Information (PII), and Granite Guardian.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ChatModeration.builder()
+ *     .hap(h -> h.input(0.8f).output(0.9f).mask(true))
+ *     .pii(p -> p.input(true).output(false).mask(false))
+ *     .graniteGuardian(g -> g.input(0.85f).mask(true))
+ *     .inputRanges(List.of(InputRanges.of(0, 100)))
+ *     .build();
+ * }</pre>
+ */
+public final class ChatModeration {
+
+    private final Hap hap;
+    private final Pii pii;
+    private final GraniteGuardian graniteGuardian;
+    private final List<InputRanges> inputRanges;
+
+    private ChatModeration(Builder builder) {
+        hap = builder.hap;
+        pii = builder.pii;
+        graniteGuardian = builder.graniteGuardian;
+        inputRanges = isNull(builder.inputRanges) ? null : List.copyOf(builder.inputRanges);
+    }
+
+    /**
+     * Returns the Hate and Profanity (HAP) moderation configuration.
+     *
+     * @return the HAP moderation settings, or {@code null} if not configured
+     */
+    public Hap hap() {
+        return hap;
+    }
+
+    /**
+     * Returns the Personally Identifiable Information (PII) moderation configuration.
+     *
+     * @return the PII moderation settings, or {@code null} if not configured
+     */
+    public Pii pii() {
+        return pii;
+    }
+
+    /**
+     * Returns the Granite Guardian moderation configuration.
+     *
+     * @return the Granite Guardian moderation settings, or {@code null} if not configured
+     */
+    public GraniteGuardian graniteGuardian() {
+        return graniteGuardian;
+    }
+
+    /**
+     * Returns the list of input ranges to which moderation should be applied.
+     *
+     * @return the list of input ranges, or {@code null} if not configured
+     */
+    public List<InputRanges> inputRanges() {
+        return inputRanges;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((hap == null) ? 0 : hap.hashCode());
+        result = prime * result + ((pii == null) ? 0 : pii.hashCode());
+        result = prime * result + ((graniteGuardian == null) ? 0 : graniteGuardian.hashCode());
+        result = prime * result + ((inputRanges == null) ? 0 : inputRanges.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ChatModeration other = (ChatModeration) obj;
+        if (hap == null) {
+            if (other.hap != null)
+                return false;
+        } else if (!hap.equals(other.hap))
+            return false;
+        if (pii == null) {
+            if (other.pii != null)
+                return false;
+        } else if (!pii.equals(other.pii))
+            return false;
+        if (graniteGuardian == null) {
+            if (other.graniteGuardian != null)
+                return false;
+        } else if (!graniteGuardian.equals(other.graniteGuardian))
+            return false;
+        if (inputRanges == null) {
+            if (other.inputRanges != null)
+                return false;
+        } else if (!inputRanges.equals(other.inputRanges))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "ChatModeration [hap=" + hap + ", pii=" + pii + ", graniteGuardian=" + graniteGuardian + ", inputRanges=" + inputRanges + "]";
+    }
+
+    /**
+     * Builder class for constructing {@link ChatModeration} instances with configurable parameters.
+     */
+    public static final class Builder {
+
+        private Hap hap;
+        private Pii pii;
+        private GraniteGuardian graniteGuardian;
+        private List<InputRanges> inputRanges;
+
+        private Builder() {}
+
+        /**
+         * Configures the Hate and Profanity (HAP) moderation via a builder consumer.
+         *
+         * <pre>{@code
+         * .hap(h -> h.input(0.8f).output(0.9f).mask(true))
+         * }</pre>
+         *
+         * @param consumer a consumer that configures the {@link Hap.Builder}
+         */
+        public Builder hap(Consumer<Hap.Builder> consumer) {
+            var b = new Hap.Builder();
+            consumer.accept(b);
+            this.hap = b.build();
+            return this;
+        }
+
+        /**
+         * Configures the Personally Identifiable Information (PII) moderation via a builder consumer.
+         *
+         * <pre>{@code
+         * .pii(p -> p.input(true).output(false).mask(false))
+         * }</pre>
+         *
+         * @param consumer a consumer that configures the {@link Pii.Builder}
+         */
+        public Builder pii(Consumer<Pii.Builder> consumer) {
+            var b = new Pii.Builder();
+            consumer.accept(b);
+            this.pii = b.build();
+            return this;
+        }
+
+        /**
+         * Configures the Granite Guardian moderation via a builder consumer.
+         *
+         * <pre>{@code
+         * .graniteGuardian(g -> g.input(0.85f).mask(true))
+         * }</pre>
+         *
+         * @param consumer a consumer that configures the {@link GraniteGuardian.Builder}
+         */
+        public Builder graniteGuardian(Consumer<GraniteGuardian.Builder> consumer) {
+            var b = new GraniteGuardian.Builder();
+            consumer.accept(b);
+            this.graniteGuardian = b.build();
+            return this;
+        }
+
+        /**
+         * Sets the list of input ranges to which moderation should be applied. Only the specified ranges of the input text will be evaluated.
+         *
+         * @param inputRanges the list of {@link InputRanges}
+         */
+        public Builder inputRanges(List<InputRanges> inputRanges) {
+            this.inputRanges = inputRanges;
+            return this;
+        }
+
+        /**
+         * Builds a {@link ChatModeration} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ChatModeration}
+         */
+        public ChatModeration build() {
+            return new ChatModeration(this);
+        }
+    }
+
+    /**
+     * Base class for detector configurations. Holds a map of properties that is serialized as a flat JSON object.
+     */
+    private static abstract class Detector {
+
+        private final Map<String, Object> properties;
+
+        Detector(DetectorBuilder<?> builder) {
+            properties = Collections.unmodifiableMap(new HashMap<>(builder.properties));
+        }
+
+        @JsonValue
+        public Map<String, Object> properties() {
+            return properties;
+        }
+
+        @Override
+        public int hashCode() {
+            return properties.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null || getClass() != obj.getClass())
+                return false;
+            Detector other = (Detector) obj;
+            return properties.equals(other.properties);
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + " [properties=" + properties + "]";
+        }
+    }
+
+    /**
+     * Abstract builder for {@link Detector} subclasses.
+     */
+    @SuppressWarnings("unchecked")
+    private static abstract class DetectorBuilder<T extends DetectorBuilder<T>> {
+
+        private final Map<String, Object> properties = new HashMap<>();
+
+        T addProperty(String name, Object value) {
+            properties.put(name, value);
+            return (T) this;
+        }
+    }
+
+    /**
+     * Hate and Profanity (HAP) moderation configuration.
+     */
+    public static final class Hap extends Detector {
+
+        private Hap(Builder builder) {
+            super(builder);
+        }
+
+        /**
+         * Builder class for constructing {@link Hap} instances with configurable parameters.
+         */
+        public static final class Builder extends DetectorBuilder<Builder> {
+
+            private Builder() {}
+
+            /**
+             * Enables HAP moderation on the input text with the given threshold.
+             *
+             * @param threshold the threshold score for triggering moderation
+             */
+            public Builder input(float threshold) {
+                return addProperty("input",
+                    Map.of(
+                        "enabled", true,
+                        "threshold", threshold));
+            }
+
+            /**
+             * Enables HAP moderation on the output text with the given threshold.
+             *
+             * @param threshold the threshold score for triggering moderation
+             */
+            public Builder output(float threshold) {
+                return addProperty("output",
+                    Map.of(
+                        "enabled", true,
+                        "threshold", threshold));
+            }
+
+            /**
+             * Configures masking behavior applied when HAP content is detected.
+             *
+             * @param removeEntityValue if {@code true}, the detected entity value is removed from the output
+             */
+            public Builder mask(boolean removeEntityValue) {
+                return addProperty("mask", Map.of("remove_entity_value", removeEntityValue));
+            }
+
+            /**
+             * Builds a {@link Hap} instance using the configured parameters.
+             *
+             * @return a new instance of {@link Hap}
+             */
+            Hap build() {
+                return new Hap(this);
+            }
+        }
+    }
+
+    /**
+     * Personally Identifiable Information (PII) moderation configuration.
+     */
+    public static final class Pii extends Detector {
+
+        private Pii(Builder builder) {
+            super(builder);
+        }
+
+        /**
+         * Builder class for constructing {@link Pii} instances with configurable parameters.
+         */
+        public static final class Builder extends DetectorBuilder<Builder> {
+
+            private Builder() {}
+
+            /**
+             * Enables or disables PII moderation on the input text.
+             *
+             * @param enabled whether PII detection on the input text is enabled
+             */
+            public Builder input(boolean enabled) {
+                return addProperty("input", Map.of("enabled", enabled));
+            }
+
+            /**
+             * Enables or disables PII moderation on the output text.
+             *
+             * @param enabled whether PII detection on the output text is enabled
+             */
+            public Builder output(boolean enabled) {
+                return addProperty("output", Map.of("enabled", enabled));
+            }
+
+            /**
+             * Configures masking behavior applied when PII is detected.
+             *
+             * @param removeEntityValue if {@code true}, the detected entity value is removed from the output
+             */
+            public Builder mask(boolean removeEntityValue) {
+                return addProperty("mask", Map.of("remove_entity_value", removeEntityValue));
+            }
+
+            /**
+             * Builds a {@link Pii} instance using the configured parameters.
+             *
+             * @return a new instance of {@link Pii}
+             */
+            Pii build() {
+                return new Pii(this);
+            }
+        }
+    }
+
+    /**
+     * Granite Guardian moderation configuration.
+     */
+    public static final class GraniteGuardian extends Detector {
+
+        private GraniteGuardian(Builder builder) {
+            super(builder);
+        }
+
+        /**
+         * Builder class for constructing {@link GraniteGuardian} instances with configurable parameters.
+         */
+        public static final class Builder extends DetectorBuilder<Builder> {
+
+            private Builder() {}
+
+            /**
+             * Enables Granite Guardian moderation on the input text with the given threshold.
+             *
+             * @param threshold the threshold score for triggering moderation
+             */
+            public Builder input(float threshold) {
+                return addProperty("input",
+                    Map.of(
+                        "enabled", true,
+                        "threshold", threshold));
+            }
+
+            /**
+             * Configures masking behavior applied when Granite Guardian detects content.
+             *
+             * @param removeEntityValue if {@code true}, the detected entity value is removed from the output
+             */
+            public Builder mask(boolean removeEntityValue) {
+                return addProperty("mask", Map.of("remove_entity_value", removeEntityValue));
+            }
+
+            /**
+             * Builds a {@link GraniteGuardian} instance using the configured parameters.
+             *
+             * @return a new instance of {@link GraniteGuardian}
+             */
+            GraniteGuardian build() {
+                return new GraniteGuardian(this);
+            }
+        }
+    }
+
+    /**
+     * Represents a range within the input text to which moderation is applied. The end index is exclusive.
+     *
+     * @param start the start index of the range (inclusive), must be &ge; 0
+     * @param end the end index of the range (exclusive), must be &ge; 0
+     */
+    public record InputRanges(Integer start, Integer end) {
+
+        /**
+         * Creates a new {@link InputRanges} instance.
+         *
+         * @param start the start index of the range (inclusive)
+         * @param end the end index of the range (exclusive)
+         * @return a new {@link InputRanges} instance
+         */
+        public static InputRanges of(Integer start, Integer end) {
+            return new InputRanges(start, end);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatRequest.java
@@ -57,6 +57,7 @@ public final class ChatRequest {
     private final List<Tool> tools;
     private final ChatParameters parameters;
     private final Thinking thinking;
+    private final ChatModeration moderations;
 
     private ChatRequest(Builder builder) {
         messages = requireNonNull(builder.messages, "messages cannot be null");
@@ -64,6 +65,7 @@ public final class ChatRequest {
         parameters = builder.parameters;
         deploymentId = builder.deploymentId;
         thinking = builder.thinking;
+        moderations = builder.moderations;
     }
 
     /**
@@ -111,6 +113,10 @@ public final class ChatRequest {
         return thinking;
     }
 
+    public ChatModeration moderations() {
+        return moderations;
+    }
+
     /**
      * Creates a builder initialized with the current state of the {@code ChatRequest}.
      *
@@ -122,7 +128,8 @@ public final class ChatRequest {
             .messages(messages)
             .tools(tools)
             .parameters(parameters)
-            .thinking(thinking);
+            .thinking(thinking)
+            .moderations(moderations);
     }
 
     /**
@@ -170,6 +177,7 @@ public final class ChatRequest {
         private List<Tool> tools;
         private ChatParameters parameters;
         private Thinking thinking;
+        private ChatModeration moderations;
 
         private Builder() {}
 
@@ -359,6 +367,11 @@ public final class ChatRequest {
             return this;
         }
 
+        public Builder moderations(ChatModeration moderations) {
+            this.moderations = moderations;
+            return this;
+        }
+
         /**
          * Builds a {@link ChatRequest} instance using the configured parameters.
          *
@@ -372,6 +385,6 @@ public final class ChatRequest {
     @Override
     public String toString() {
         return "ChatRequest [deploymentId=" + deploymentId + ", messages=" + messages + ", tools=" + tools + ", parameters=" + parameters
-            + ", thinking=" + thinking + "]";
+            + ", thinking=" + thinking + ", moderations=" + moderations + "]";
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
@@ -5,7 +5,9 @@
 package com.ibm.watsonx.ai.chat;
 
 import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 import java.util.List;
+import java.util.Map;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
@@ -24,7 +26,7 @@ public final class ChatResponse {
      * @param message the message produced by the model for this choice
      * @param finishReason the reason the model stopped generating tokens for this choice
      */
-    public static record ResultChoice(Integer index, ResultMessage message, String finishReason) {
+    public record ResultChoice(Integer index, ResultMessage message, String finishReason) {
 
         /**
          * Returns a copy of this {@link ResultChoice} with a new result message.
@@ -47,6 +49,50 @@ public final class ChatResponse {
         }
     }
 
+    /**
+     * Represents a single moderation result detected in the chat response.
+     * <p>
+     * A moderation result describes a specific match found by the moderation system, including its probability score, whether it was found in the
+     * input or output text, its position within the text, the detected entity type, and optionally the matched word.
+     *
+     * @param score the probability that this is a real match (0.0 to 1.0)
+     * @param input {@code true} if this was found in the input text, {@code false} if found in the output
+     * @param position the range within the text where the match was found
+     * @param entity the entity type identified by the moderation (e.g., {@code "EmailAddress"})
+     * @param word the text that was identified for this entity
+     */
+    public record ModerationResult(float score, boolean input, Position position, String entity, String word) {
+
+        /**
+         * Represents a range of text identified by a moderation result. The {@code end} index is exclusive.
+         *
+         * @param start the start index of the range (inclusive), must be &ge; 0
+         * @param end the end index of the range (exclusive), must be &ge; 0
+         */
+        public record Position(int start, int end) {}
+    }
+
+    /**
+     * Represents a detection entry associated with a specific choice.
+     *
+     * @param choiceIndex the index of the choice this detection refers to
+     * @param results the list of detection results found for the choice
+     */
+    public record DetectionEntry(int choiceIndex, List<DetectionResult> results) {}
+
+    /**
+     * Represents a single detection result produced by a detector.
+     *
+     * @param detectorId the identifier of the detector that produced this result (e.g., {@code "en_syntax_rbr_pii"})
+     * @param detectionType the type of detection (e.g., {@code "pii"})
+     * @param detection the specific detection label (e.g., {@code "PhoneNumber"})
+     * @param score the probability that this is a real match (0.0 to 1.0)
+     * @param text the text that was identified
+     * @param start the start index of the match (inclusive)
+     * @param end the end index of the match (exclusive)
+     */
+    public record DetectionResult(String detectorId, String detectionType, String detection, double score, String text, int start, int end) {}
+
     private final String id;
     private final String object;
     private final String modelId;
@@ -57,6 +103,8 @@ public final class ChatResponse {
     private final String createdAt;
     private final ChatUsage usage;
     private final ExtractionTags extractionTags;
+    private final Map<String, List<ModerationResult>> moderations;
+    private final Map<String, List<DetectionEntry>> detections;
 
     private ChatResponse(Builder builder) {
         id = builder.id;
@@ -69,6 +117,12 @@ public final class ChatResponse {
         createdAt = builder.createdAt;
         usage = builder.usage;
         extractionTags = builder.extractionTags;
+        moderations = isNull(builder.moderations) ? null
+            : builder.moderations.entrySet().stream()
+                .collect(toUnmodifiableMap(Map.Entry::getKey, e -> List.copyOf(e.getValue())));
+        detections = isNull(builder.detections) ? null
+            : builder.detections.entrySet().stream()
+                .collect(toUnmodifiableMap(Map.Entry::getKey, e -> List.copyOf(e.getValue())));
     }
 
     /**
@@ -153,6 +207,25 @@ public final class ChatResponse {
     }
 
     /**
+     * Returns the moderation results detected in the chat response, keyed by detector name (e.g. {@code "pii"}, {@code "hap"},
+     * {@code "granite_guardian"}).
+     *
+     * @return a map from detector name to its list of {@link ModerationResult}
+     */
+    public Map<String, List<ModerationResult>> moderations() {
+        return moderations;
+    }
+
+    /**
+     * Returns the detection results reported in the chat response, keyed by the target position (e.g. {@code "input"}, {@code "output"}).
+     *
+     * @return a map from target position to its list of {@link DetectionEntry}
+     */
+    public Map<String, List<DetectionEntry>> detections() {
+        return detections;
+    }
+
+    /**
      * Retrieves the finish reason for the current chat response.
      *
      * @return a {@code String} representing the reason why the response generation finished
@@ -232,7 +305,9 @@ public final class ChatResponse {
             .modelVersion(this.modelVersion)
             .createdAt(this.createdAt)
             .usage(this.usage)
-            .extractionTags(this.extractionTags);
+            .extractionTags(this.extractionTags)
+            .moderations(this.moderations)
+            .detections(this.detections);
     }
 
     /**
@@ -264,6 +339,8 @@ public final class ChatResponse {
         private String createdAt;
         private ChatUsage usage;
         private ExtractionTags extractionTags;
+        private Map<String, List<ModerationResult>> moderations;
+        private Map<String, List<DetectionEntry>> detections;
 
         /**
          * Sets the unique identifier of the chat response.
@@ -366,6 +443,26 @@ public final class ChatResponse {
         }
 
         /**
+         * Sets the moderation results detected in the chat response, keyed by detector name.
+         *
+         * @param moderations a map from detector name to its list of {@link ModerationResult}
+         */
+        public Builder moderations(Map<String, List<ModerationResult>> moderations) {
+            this.moderations = moderations;
+            return this;
+        }
+
+        /**
+         * Sets the detection results reported in the chat response, keyed by the target position (e.g. {@code "input"}, {@code "output"}).
+         *
+         * @param detections a map from target position to its list of {@link DetectionEntry}
+         */
+        public Builder detections(Map<String, List<DetectionEntry>> detections) {
+            this.detections = detections;
+            return this;
+        }
+
+        /**
          * Builds a {@link ChatResponse} instance using the configured parameters.
          *
          * @return a new instance of {@link ChatResponse}
@@ -389,6 +486,8 @@ public final class ChatResponse {
         result = prime * result + ((createdAt == null) ? 0 : createdAt.hashCode());
         result = prime * result + ((usage == null) ? 0 : usage.hashCode());
         result = prime * result + ((extractionTags == null) ? 0 : extractionTags.hashCode());
+        result = prime * result + ((moderations == null) ? 0 : moderations.hashCode());
+        result = prime * result + ((detections == null) ? 0 : detections.hashCode());
         return result;
     }
 
@@ -451,12 +550,23 @@ public final class ChatResponse {
                 return false;
         } else if (!extractionTags.equals(other.extractionTags))
             return false;
+        if (moderations == null) {
+            if (other.moderations != null)
+                return false;
+        } else if (!moderations.equals(other.moderations))
+            return false;
+        if (detections == null) {
+            if (other.detections != null)
+                return false;
+        } else if (!detections.equals(other.detections))
+            return false;
         return true;
     }
 
     @Override
     public String toString() {
         return "ChatResponse [id=" + id + ", object=" + object + ", modelId=" + modelId + ", model=" + model + ", choices=" + choices + ", created="
-            + created + ", modelVersion=" + modelVersion + ", createdAt=" + createdAt + ", usage=" + usage + "]";
+            + created + ", modelVersion=" + modelVersion + ", createdAt=" + createdAt + ", usage=" + usage + ", extractionTags=" + extractionTags
+            + ", moderations=" + moderations + ", detections=" + detections + "]";
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatUtility.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatUtility.java
@@ -94,6 +94,7 @@ public class ChatUtility {
             .includeReasoning(includeReasoning)
             .reasoningEffort(thinkingEffort)
             .chatTemplateKwargs(chatTemplateKwargs)
+            .moderations(chatRequest.moderations())
             .crypto(getOrDefault(parameters.crypto(), defaultParameters.crypto()))
             .build();
     }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/Masker.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/Masker.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import com.ibm.watsonx.ai.chat.ChatResponse.ModerationResult;
+
+/**
+ * Utility for applying client-side masking to text using {@link ChatResponse#moderations()} results.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ChatResponse response = chatService.chat(request);
+ * String content = response.toAssistantMessage().content();
+ *
+ * // Default: replace each matched range with asterisks of the same length.
+ * String masked = Masker.mask(content, response);
+ *
+ * // Custom: replace each match with a label like "[PhoneNumber]".
+ * String labelled = Masker.mask(content, response, m -> "[" + m.entity() + "]");
+ * }</pre>
+ */
+public final class Masker {
+
+    private Masker() {}
+
+    /**
+     * Masks the output moderation matches in the given content using asterisks ({@code *}) repeated for the length of each match.
+     *
+     * @param content the text to mask
+     * @param response the chat response containing the moderation results
+     * @return the masked content, or the original content if there is nothing to mask
+     */
+    public static String mask(String content, ChatResponse response) {
+        return mask(content, response, m -> "*".repeat(m.position().end() - m.position().start()));
+    }
+
+    /**
+     * Masks the output moderation matches in the given content using a custom replacer.
+     *
+     * @param content the text to mask
+     * @param response the chat response containing the moderation results
+     * @param replacer a function that returns the replacement string for each matched {@link ModerationResult}
+     * @return the masked content, or the original content if there is nothing to mask
+     */
+    public static String mask(String content, ChatResponse response, Function<ModerationResult, String> replacer) {
+        if (isNull(content) || isNull(response) || isNull(response.moderations()))
+            return content;
+
+        var matches = response.moderations().values().stream()
+            .flatMap(List::stream)
+            .filter(m -> !m.input() && nonNull(m.position()))
+            .sorted(Comparator.comparingInt((ModerationResult m) -> m.position().start()).reversed())
+            .toList();
+
+        if (matches.isEmpty())
+            return content;
+
+        var sb = new StringBuilder(content);
+        for (var m : matches) {
+            int start = m.position().start();
+            int end = m.position().end();
+            if (start < 0 || end > sb.length() || start >= end)
+                continue;
+            sb.replace(start, end, replacer.apply(m));
+        }
+        return sb.toString();
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/SseEventProcessor.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/SseEventProcessor.java
@@ -9,9 +9,13 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import com.ibm.watsonx.ai.chat.ChatResponse.DetectionEntry;
+import com.ibm.watsonx.ai.chat.ChatResponse.DetectionResult;
+import com.ibm.watsonx.ai.chat.ChatResponse.ModerationResult;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.SseEventProcessor.CallbackEvent.CompleteToolCallEvent;
 import com.ibm.watsonx.ai.chat.SseEventProcessor.CallbackEvent.ErrorEvent;
@@ -49,6 +53,8 @@ public class SseEventProcessor {
     private volatile String modelVersion;
     private volatile boolean pendingSSEError = false;
     private volatile ChatUsage chatUsage;
+    private volatile Map<String, List<ModerationResult>> moderations;
+    private volatile Map<String, List<DetectionEntry>> detections;
     private final Map<Integer, StringBuilder> contentBuffers = new ConcurrentHashMap<>();
     private final Map<Integer, StringBuilder> thinkingBuffers = new ConcurrentHashMap<>();
     private final Map<Integer, List<StreamingToolFetcher>> toolFetchers = new ConcurrentHashMap<>();
@@ -186,6 +192,12 @@ public class SseEventProcessor {
 
         if (nonNull(chunk.usage()))
             chatUsage = chunk.usage();
+
+        if (nonNull(chunk.moderations()) && !chunk.moderations().isEmpty())
+            moderations = mergeModerations(moderations, chunk.moderations());
+
+        if (nonNull(chunk.detections()) && !chunk.detections().isEmpty())
+            detections = mergeDetections(detections, chunk.detections());
 
         if (chunk.choices().size() == 0) {
 
@@ -369,6 +381,8 @@ public class SseEventProcessor {
             .extractionTags(extractionTags)
             .usage(chatUsage)
             .choices(choices)
+            .moderations(moderations)
+            .detections(detections)
             .build();
     }
 
@@ -386,5 +400,43 @@ public class SseEventProcessor {
             tool -> tool.function().name(),
             Tool::hasParameters
         ));
+    }
+
+    /**
+     * Concatenates moderation matches from the current chunk into the accumulator, keyed by detector name.
+     */
+    private static Map<String, List<ModerationResult>> mergeModerations(Map<String, List<ModerationResult>> acc,
+        Map<String, List<ModerationResult>> chunk) {
+
+        var merged = isNull(acc) ? new LinkedHashMap<String, List<ModerationResult>>() : new LinkedHashMap<>(acc);
+
+        chunk.forEach((detector, results) -> {
+            var list = merged.computeIfAbsent(detector, k -> new ArrayList<>());
+            list.addAll(results);
+        });
+
+        return merged;
+    }
+
+    /**
+     * Concatenates detection entries from the current chunk into the accumulator, keyed by target position and grouped by {@code choiceIndex}.
+     */
+    private static Map<String, List<DetectionEntry>> mergeDetections(Map<String, List<DetectionEntry>> acc, Map<String, List<DetectionEntry>> chunk) {
+
+        var merged = isNull(acc) ? new LinkedHashMap<String, List<DetectionEntry>>() : new LinkedHashMap<>(acc);
+
+        chunk.forEach((target, chunkEntries) -> {
+            var byChoice = new LinkedHashMap<Integer, List<DetectionResult>>();
+            var existing = merged.get(target);
+            if (nonNull(existing))
+                existing.forEach(e -> byChoice.computeIfAbsent(e.choiceIndex(), k -> new ArrayList<>()).addAll(e.results()));
+            chunkEntries.forEach(e -> byChoice.computeIfAbsent(e.choiceIndex(), k -> new ArrayList<>()).addAll(e.results()));
+
+            var rebuilt = new ArrayList<DetectionEntry>();
+            byChoice.forEach((idx, results) -> rebuilt.add(new DetectionEntry(idx, results)));
+            merged.put(target, rebuilt);
+        });
+
+        return merged;
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/PartialChatResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/PartialChatResponse.java
@@ -5,6 +5,9 @@
 package com.ibm.watsonx.ai.chat.model;
 
 import java.util.List;
+import java.util.Map;
+import com.ibm.watsonx.ai.chat.ChatResponse.DetectionEntry;
+import com.ibm.watsonx.ai.chat.ChatResponse.ModerationResult;
 
 /**
  * Represents the partial response from a chat streaming request.
@@ -18,9 +21,12 @@ import java.util.List;
  * @param modelVersion the version of the model that produced the response
  * @param createdAt the ISO 8601 timestamp when the response was created
  * @param usage the token usage statistics, if present
+ * @param moderations the moderation results detected in this chunk, keyed by detector name
+ * @param detections the detection results reported in this chunk, keyed by target position
  */
 public record PartialChatResponse(String id, String object, String modelId, String model,
-    List<ResultChoice> choices, Long created, String modelVersion, String createdAt, ChatUsage usage) {
+    List<ResultChoice> choices, Long created, String modelVersion, String createdAt, ChatUsage usage,
+    Map<String, List<ModerationResult>> moderations, Map<String, List<DetectionEntry>> detections) {
 
     /**
      * Returns the index of the first result choice.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/TextChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/TextChatRequest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import com.ibm.watsonx.ai.Crypto;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.model.ChatParameters.JsonSchemaObject;
 import com.ibm.watsonx.ai.chat.model.ChatParameters.ResponseFormat;
 
@@ -51,6 +52,7 @@ public final class TextChatRequest {
     private final Double repetitionPenalty;
     private final Double lengthPenalty;
     private final String context;
+    private final ChatModeration moderations;
     private final Crypto crypto;
 
     private TextChatRequest(Builder builder) {
@@ -92,6 +94,7 @@ public final class TextChatRequest {
         guidedGrammar = builder.guidedGrammar;
         repetitionPenalty = builder.repetitionPenalty;
         lengthPenalty = builder.lengthPenalty;
+        moderations = builder.moderations;
         crypto = nonNull(builder.crypto) ? new Crypto(builder.crypto) : null;
     }
 
@@ -215,6 +218,10 @@ public final class TextChatRequest {
         return lengthPenalty;
     }
 
+    public ChatModeration moderations() {
+        return moderations;
+    }
+
     public Crypto crypto() {
         return crypto;
     }
@@ -254,6 +261,7 @@ public final class TextChatRequest {
         private Double repetitionPenalty;
         private Double lengthPenalty;
         private String context;
+        private ChatModeration moderations;
         private String crypto;
 
         private Builder() {}
@@ -405,6 +413,11 @@ public final class TextChatRequest {
 
         public Builder jsonSchema(JsonSchemaObject jsonSchema) {
             this.jsonSchema = jsonSchema;
+            return this;
+        }
+
+        public Builder moderations(ChatModeration moderations) {
+            this.moderations = moderations;
             return this;
         }
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/deployment/DeploymentService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/deployment/DeploymentService.java
@@ -334,6 +334,7 @@ public class DeploymentService extends WatsonxService implements ChatProvider, T
             .lengthPenalty(getOrDefault(parameters.lengthPenalty(), defaultParameters.lengthPenalty()))
             .includeReasoning(includeReasoning)
             .reasoningEffort(thinkingEffort)
+            .moderations(chatRequest.moderations())
             .chatTemplateKwargs(chatTemplateKwargs)
             .build();
     }

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/DetectionServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/DetectionServiceTest.java
@@ -94,7 +94,7 @@ public class DetectionServiceTest extends AbstractWatsonxTest {
                 .detectors(
                     Pii.builder().build(),
                     Hap.builder().threshold(0.1).build(),
-                    GraniteGuardian.builder().threshold(0.2).addProperty("val", "test").build())
+                    GraniteGuardian.builder().threshold(0.2).build())
                 .build();
 
             service.detect(request);
@@ -111,8 +111,7 @@ public class DetectionServiceTest extends AbstractWatsonxTest {
                                 "threshold": 0.1
                             },
                             "granite_guardian": {
-                                "threshold": 0.2,
-                                "val": "test"
+                                "threshold": 0.2
                             }
                         }
                     }

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/ToStringTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/ToStringTest.java
@@ -10,6 +10,7 @@ import com.ibm.watsonx.ai.batch.BatchCancelRequest;
 import com.ibm.watsonx.ai.batch.BatchCreateRequest;
 import com.ibm.watsonx.ai.batch.BatchListRequest;
 import com.ibm.watsonx.ai.batch.BatchRetrieveRequest;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.schema.ArraySchema;
 import com.ibm.watsonx.ai.chat.model.schema.BooleanSchema;
@@ -353,10 +354,10 @@ public class ToStringTest {
 
     @Test
     void pii_toString_includes_name_and_properties() {
-        var s = Pii.builder().threshold(0.8).build().toString();
+        var s = Pii.builder().build().toString();
         assertTrue(s.contains("Pii"), s);
         assertTrue(s.contains("name=pii"), s);
-        assertTrue(s.contains("threshold"), s);
+        assertTrue(s.contains("properties"), s);
     }
 
     @Test
@@ -373,6 +374,50 @@ public class ToStringTest {
         assertTrue(s.contains("GraniteGuardian"), s);
         assertTrue(s.contains("name=granite_guardian"), s);
         assertTrue(s.contains("threshold"), s);
+    }
+
+    // -------------------------------------------------------------------------
+    // ChatModeration hierarchy
+    // -------------------------------------------------------------------------
+
+    @Test
+    void chat_moderation_toString_includes_configured_detectors() {
+        var s = ChatModeration.builder()
+            .hap(h -> h.output(0.9f))
+            .pii(p -> p.output(true))
+            .build()
+            .toString();
+        assertTrue(s.contains("ChatModeration"), s);
+        assertTrue(s.contains("hap="), s);
+        assertTrue(s.contains("pii="), s);
+    }
+
+    @Test
+    void chat_moderation_hap_toString_includes_class_name_and_properties() {
+        var moderation = ChatModeration.builder().hap(h -> h.output(0.9f).mask(true)).build();
+        var s = moderation.hap().toString();
+        assertTrue(s.contains("Hap"), s);
+        assertTrue(s.contains("properties"), s);
+        assertTrue(s.contains("output"), s);
+        assertTrue(s.contains("mask"), s);
+    }
+
+    @Test
+    void chat_moderation_pii_toString_includes_class_name_and_properties() {
+        var moderation = ChatModeration.builder().pii(p -> p.output(true)).build();
+        var s = moderation.pii().toString();
+        assertTrue(s.contains("Pii"), s);
+        assertTrue(s.contains("properties"), s);
+        assertTrue(s.contains("output"), s);
+    }
+
+    @Test
+    void chat_moderation_granite_guardian_toString_includes_class_name_and_properties() {
+        var moderation = ChatModeration.builder().graniteGuardian(g -> g.input(0.85f)).build();
+        var s = moderation.graniteGuardian().toString();
+        assertTrue(s.contains("GraniteGuardian"), s);
+        assertTrue(s.contains("properties"), s);
+        assertTrue(s.contains("input"), s);
     }
 
     // -------------------------------------------------------------------------

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/MaskerTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/MaskerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import com.ibm.watsonx.ai.chat.ChatResponse.ModerationResult;
+import com.ibm.watsonx.ai.chat.ChatResponse.ModerationResult.Position;
+
+public class MaskerTest {
+
+    @Test
+    void should_mask_single_output_match_with_asterisks() {
+        var content = "Sure, your phone number is 3572865321.";
+        var mod = new ModerationResult(0.8f, false, new Position(27, 37), "PhoneNumber", null);
+        var response = ChatResponse.build().moderations(Map.of("pii", List.of(mod))).build();
+
+        assertEquals("Sure, your phone number is **********.", Masker.mask(content, response));
+    }
+
+    @Test
+    void should_mask_multiple_matches_in_correct_order() {
+        var content = "Call 3572865321 or 5551234567 please.";
+        var mod1 = new ModerationResult(0.9f, false, new Position(5, 15), "PhoneNumber", null);
+        var mod2 = new ModerationResult(0.9f, false, new Position(19, 29), "PhoneNumber", null);
+        var response = ChatResponse.build().moderations(Map.of("pii", List.of(mod1, mod2))).build();
+
+        assertEquals("Call ********** or ********** please.", Masker.mask(content, response));
+    }
+
+    @Test
+    void should_ignore_input_moderation_matches() {
+        var content = "Sure, your phone number is 3572865321.";
+        var mod = new ModerationResult(0.8f, true, new Position(27, 37), "PhoneNumber", null);
+        var response = ChatResponse.build().moderations(Map.of("pii", List.of(mod))).build();
+
+        assertEquals(content, Masker.mask(content, response));
+    }
+
+    @Test
+    void should_use_custom_replacer_when_provided() {
+        var content = "Sure, your phone number is 3572865321.";
+        var mod = new ModerationResult(0.8f, false, new Position(27, 37), "PhoneNumber", null);
+        var response = ChatResponse.build().moderations(Map.of("pii", List.of(mod))).build();
+
+        assertEquals("Sure, your phone number is [PhoneNumber].",
+            Masker.mask(content, response, m -> "[" + m.entity() + "]"));
+    }
+
+    @Test
+    void should_return_original_content_when_no_moderations_present() {
+        var content = "Nothing to mask here.";
+        var response = ChatResponse.build().build();
+
+        assertEquals(content, Masker.mask(content, response));
+    }
+
+    @Test
+    void should_return_original_content_when_response_is_null() {
+        var content = "Nothing to mask here.";
+        assertEquals(content, Masker.mask(content, null));
+    }
+
+    @Test
+    void should_return_null_when_content_is_null() {
+        var response = ChatResponse.build().build();
+        assertNull(Masker.mask(null, response));
+    }
+
+    @Test
+    void should_skip_matches_with_invalid_positions() {
+        var content = "Short text";
+        var badMod = new ModerationResult(0.8f, false, new Position(50, 60), "PhoneNumber", null);
+        var response = ChatResponse.build().moderations(Map.of("pii", List.of(badMod))).build();
+
+        assertEquals(content, Masker.mask(content, response));
+    }
+
+    @Test
+    void should_mask_matches_across_multiple_detectors() {
+        var content = "You are stupid, phone: 3572865321.";
+        var hap = new ModerationResult(0.9f, false, new Position(8, 14), "profanity", "stupid");
+        var pii = new ModerationResult(0.8f, false, new Position(23, 33), "PhoneNumber", "3572865321");
+        var response = ChatResponse.build()
+            .moderations(Map.of("hap", List.of(hap), "pii", List.of(pii)))
+            .build();
+
+        assertEquals("You are ******, phone: **********.", Masker.mask(content, response));
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ModerationTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ModerationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import com.ibm.watsonx.ai.chat.ChatModeration.InputRanges;
+import com.ibm.watsonx.ai.core.Json;
+
+public class ModerationTest {
+
+    @Test
+    void should_serialize_moderation_parameters_correctly() throws Exception {
+
+        var EXPECTED = """
+            {
+                "hap": {
+                  "input": {
+                    "enabled": true,
+                    "threshold": 0.8
+                  },
+                  "output": {
+                    "enabled": true,
+                    "threshold": 0.9
+                  },
+                  "mask": {
+                    "remove_entity_value": true
+                  }
+                },
+                "pii": {
+                  "input": {
+                    "enabled": true
+                  },
+                  "output": {
+                    "enabled": false
+                  },
+                  "mask": {
+                    "remove_entity_value": false
+                  }
+                },
+                "granite_guardian": {
+                  "input": {
+                    "enabled": true,
+                    "threshold": 0.85
+                  },
+                  "mask": {
+                    "remove_entity_value": true
+                  }
+                },
+                "input_ranges": [
+                  {
+                    "start": 0,
+                    "end": 50
+                  },
+                  {
+                    "start": 100,
+                    "end": 150
+                  }
+                ]
+            }""";
+
+        var moderation = ChatModeration.builder()
+            .hap(h -> h.input(0.8f).output(0.9f).mask(true))
+            .pii(p -> p.input(true).output(false).mask(false))
+            .graniteGuardian(g -> g.input(0.85f).mask(true))
+            .inputRanges(List.of(InputRanges.of(0, 50), InputRanges.of(100, 150)))
+            .build();
+
+        JSONAssert.assertEquals(EXPECTED, Json.toJson(moderation), true);
+    }
+
+    @Test
+    void should_be_equal_when_configurations_match() {
+
+        var a = ChatModeration.builder()
+            .hap(h -> h.input(0.8f).mask(true))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+
+        var b = ChatModeration.builder()
+            .hap(h -> h.input(0.8f).mask(true))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void should_not_be_equal_when_detector_properties_differ() {
+
+        var a = ChatModeration.builder().hap(h -> h.input(0.8f)).build();
+        var b = ChatModeration.builder().hap(h -> h.input(0.9f)).build();
+
+        assertNotEquals(a, b);
+        assertNotEquals(a.hap(), b.hap());
+    }
+
+    @Test
+    void should_not_be_equal_when_detector_types_differ_even_with_same_properties() {
+
+        var hap = ChatModeration.builder().hap(h -> h.output(0.8f)).build().hap();
+        var graniteGuardian = ChatModeration.builder().graniteGuardian(g -> g.input(0.8f)).build().graniteGuardian();
+
+        assertNotEquals(hap, graniteGuardian);
+    }
+
+    @Test
+    void should_satisfy_equals_contract() {
+
+        var moderation = ChatModeration.builder().hap(h -> h.input(0.8f)).build();
+
+        // Reflexive
+        assertEquals(moderation, moderation);
+        assertEquals(moderation.hap(), moderation.hap());
+
+        // Null
+        assertNotEquals(moderation, null);
+        assertNotEquals(moderation.hap(), null);
+
+        // Different class
+        assertNotEquals(moderation, "not a ChatModeration");
+        assertNotEquals(moderation.hap(), "not a detector");
+    }
+
+    @Test
+    void should_detect_field_by_field_differences_in_equals() {
+
+        var base = ChatModeration.builder()
+            .hap(h -> h.input(0.8f))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+
+        // Same as base
+        var same = ChatModeration.builder()
+            .hap(h -> h.input(0.8f))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+        assertEquals(base, same);
+
+        // hap differs
+        var hapDiff = ChatModeration.builder()
+            .hap(h -> h.input(0.5f))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+        assertNotEquals(base, hapDiff);
+
+        // pii differs
+        var piiDiff = ChatModeration.builder()
+            .hap(h -> h.input(0.8f))
+            .pii(p -> p.output(false))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+        assertNotEquals(base, piiDiff);
+
+        // graniteGuardian differs
+        var ggDiff = ChatModeration.builder()
+            .hap(h -> h.input(0.8f))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.5f))
+            .inputRanges(List.of(InputRanges.of(0, 50)))
+            .build();
+        assertNotEquals(base, ggDiff);
+
+        // inputRanges differs
+        var rangesDiff = ChatModeration.builder()
+            .hap(h -> h.input(0.8f))
+            .pii(p -> p.output(true))
+            .graniteGuardian(g -> g.input(0.85f))
+            .inputRanges(List.of(InputRanges.of(0, 100)))
+            .build();
+        assertNotEquals(base, rangesDiff);
+
+        // Null vs non-null on each field
+        var empty = ChatModeration.builder().build();
+        assertNotEquals(empty, base);
+        assertNotEquals(base, empty);
+        assertNotEquals(empty, ChatModeration.builder().hap(h -> h.input(0.8f)).build());
+        assertNotEquals(empty, ChatModeration.builder().pii(p -> p.output(true)).build());
+        assertNotEquals(empty, ChatModeration.builder().graniteGuardian(g -> g.input(0.85f)).build());
+        assertNotEquals(empty, ChatModeration.builder().inputRanges(List.of(InputRanges.of(0, 50))).build());
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/SseEventProcessorTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/SseEventProcessorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import com.ibm.watsonx.ai.chat.SseEventProcessor.CallbackEvent.PartialResponseEvent;
+
+public class SseEventProcessorTest {
+
+    @Test
+    void should_propagate_moderations_and_detections_from_streaming_chunks() {
+
+        var processor = new SseEventProcessor(List.of(), null);
+
+        var firstChunk = "data: "
+            + """
+                {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"ibm/granite-4-h-small","model":"ibm/granite-4-h-small",\
+                "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":"Sure, your phone numbers are 3572865321."}}],\
+                "created":1785060893,"model_version":"4.0.0","created_at":"2026-07-26T10:14:53.380Z",\
+                "moderations":{"pii":[{"score":0.8,"input":false,"position":{"start":29,"end":39},"entity":"PhoneNumber","word":"3572865321"}]},\
+                "detections":{"output":[{"choice_index":0,"results":[{"detector_id":"en_syntax_rbr_pii","detection_type":"pii","detection":"PhoneNumber","score":0.8,"text":"3572865321","start":29,"end":39}]}]}}""";
+
+        var stopChunk = "data: " + """
+            {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"ibm/granite-4-h-small","model":"ibm/granite-4-h-small",\
+            "choices":[{"index":0,"finish_reason":"stop","delta":{"role":"assistant"}}],\
+            "created":1785060893,"model_version":"4.0.0","created_at":"2026-07-26T10:14:53.381Z"}""";
+
+        var usageChunk = "data: " + """
+            {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"ibm/granite-4-h-small","model":"ibm/granite-4-h-small",\
+            "choices":[],"created":1785060893,"model_version":"4.0.0","created_at":"2026-07-26T10:14:53.381Z",\
+            "usage":{"completion_tokens":19,"prompt_tokens":49,"total_tokens":68}}""";
+
+        processor.processChunk(firstChunk);
+        processor.processChunk(stopChunk);
+        processor.processChunk(usageChunk);
+
+        var response = processor.buildResponse();
+
+        assertNotNull(response.moderations());
+        assertEquals(1, response.moderations().get("pii").size());
+        var mod = response.moderations().get("pii").get(0);
+        assertEquals(0.8f, mod.score());
+        assertEquals("PhoneNumber", mod.entity());
+        assertEquals(29, mod.position().start());
+        assertEquals(39, mod.position().end());
+
+        assertNotNull(response.detections());
+        assertEquals(1, response.detections().get("output").size());
+        var det = response.detections().get("output").get(0);
+        assertEquals(0, det.choiceIndex());
+        assertEquals("en_syntax_rbr_pii", det.results().get(0).detectorId());
+        assertEquals("PhoneNumber", det.results().get(0).detection());
+
+        assertNotNull(response.usage());
+        assertEquals(68, response.usage().totalTokens());
+        assertEquals("stop", response.choices().get(0).finishReason());
+    }
+
+    @Test
+    void should_aggregate_moderations_and_detections_across_multiple_chunks() {
+
+        var processor = new SseEventProcessor(List.of(), null);
+
+        // Chunk 1: empty moderations, empty output detections (the shape mistral emits before any match).
+        var chunk1 = "data: " + """
+            {"id":"chatcmpl-2","object":"chat.completion.chunk","model_id":"mistral","model":"mistral",\
+            "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":"Here are the phone numbers you provided:"}}],\
+            "created":1,"model_version":"1.0","created_at":"2026-07-26T00:00:00.000Z",\
+            "moderations":{},"detections":{"output":[{"choice_index":0,"results":[]}]}}""";
+
+        // Chunk 2: first PII match.
+        var chunk2 = "data: "
+            + """
+                {"id":"chatcmpl-2","object":"chat.completion.chunk","model_id":"mistral","model":"mistral",\
+                "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":"\\n1. 357-286-5321"}}],\
+                "created":1,"model_version":"1.0","created_at":"2026-07-26T00:00:00.001Z",\
+                "moderations":{"pii":[{"score":0.8,"input":false,"position":{"start":7,"end":19},"entity":"PhoneNumber","word":"357-286-5321"}]},\
+                "detections":{"output":[{"choice_index":0,"results":[{"detector_id":"en_syntax_rbr_pii","detection_type":"pii","detection":"PhoneNumber","score":0.8,"text":"357-286-5321","start":7,"end":19}]}]}}""";
+
+        // Chunk 3: second PII match, finish_reason=stop.
+        var chunk3 = "data: "
+            + """
+                {"id":"chatcmpl-2","object":"chat.completion.chunk","model_id":"mistral","model":"mistral",\
+                "choices":[{"index":0,"finish_reason":"stop","delta":{"role":"assistant","content":"\\n2. 213-234-8765"}}],\
+                "created":1,"model_version":"1.0","created_at":"2026-07-26T00:00:00.002Z",\
+                "moderations":{"pii":[{"score":0.8,"input":false,"position":{"start":6,"end":18},"entity":"PhoneNumber","word":"213-234-8765"}]},\
+                "detections":{"output":[{"choice_index":0,"results":[{"detector_id":"en_syntax_rbr_pii","detection_type":"pii","detection":"PhoneNumber","score":0.8,"text":"213-234-8765","start":6,"end":18}]}]}}""";
+
+        processor.processChunk(chunk1);
+        processor.processChunk(chunk2);
+        processor.processChunk(chunk3);
+
+        var response = processor.buildResponse();
+
+        var piiMatches = response.moderations().get("pii");
+        assertNotNull(piiMatches);
+        assertEquals(2, piiMatches.size(), "moderations from all chunks should be aggregated");
+        assertEquals("357-286-5321", piiMatches.get(0).word());
+        assertEquals("213-234-8765", piiMatches.get(1).word());
+
+        var outputEntries = response.detections().get("output");
+        assertNotNull(outputEntries);
+        assertEquals(1, outputEntries.size(), "detections grouped by choice_index should collapse to one entry");
+        var results = outputEntries.get(0).results();
+        assertEquals(2, results.size(), "detection results from all chunks should be aggregated for the same choice_index");
+        assertTrue(results.stream().anyMatch(r -> "357-286-5321".equals(r.text())));
+        assertTrue(results.stream().anyMatch(r -> "213-234-8765".equals(r.text())));
+    }
+
+    @Test
+    void should_expose_per_chunk_moderations_on_partial_response_event() {
+
+        var processor = new SseEventProcessor(List.of(), null);
+
+        // Chunk 1: content without any PII match, no moderations flagged.
+        var chunk1 = "data: " + """
+            {"id":"chatcmpl-3","object":"chat.completion.chunk","model_id":"mistral","model":"mistral",\
+            "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":"Here are the phone numbers you provided:"}}],\
+            "created":1,"model_version":"1.0","created_at":"2026-07-26T00:00:00.000Z",\
+            "moderations":{},"detections":{"output":[{"choice_index":0,"results":[]}]}}""";
+
+        // Chunk 2: content contains a PII match, moderations populated.
+        var chunk2 = "data: "
+            + """
+                {"id":"chatcmpl-3","object":"chat.completion.chunk","model_id":"mistral","model":"mistral",\
+                "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":"\\n1. 357-286-5321"}}],\
+                "created":1,"model_version":"1.0","created_at":"2026-07-26T00:00:00.001Z",\
+                "moderations":{"pii":[{"score":0.8,"input":false,"position":{"start":7,"end":19},"entity":"PhoneNumber","word":"357-286-5321"}]},\
+                "detections":{"output":[{"choice_index":0,"results":[{"detector_id":"en_syntax_rbr_pii","detection_type":"pii","detection":"PhoneNumber","score":0.8,"text":"357-286-5321","start":7,"end":19}]}]}}""";
+
+        var events1 = processor.processChunk(chunk1);
+        var events2 = processor.processChunk(chunk2);
+
+        var partial1 = events1.events().stream()
+            .filter(PartialResponseEvent.class::isInstance)
+            .map(PartialResponseEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+
+        // Chunk 1 has no PII match: moderations is empty, detections.output[0].results is empty.
+        assertNotNull(partial1.chunk().moderations());
+        assertTrue(partial1.chunk().moderations().isEmpty());
+        assertNotNull(partial1.chunk().detections());
+        assertTrue(partial1.chunk().detections().get("output").get(0).results().isEmpty());
+
+        var partial2 = events2.events().stream()
+            .filter(PartialResponseEvent.class::isInstance)
+            .map(PartialResponseEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+
+        // Chunk 2 carries the PII match: a handler can react (block, tag, log) at this precise moment.
+        var chunkPii = partial2.chunk().moderations().get("pii");
+        assertNotNull(chunkPii);
+        assertEquals(1, chunkPii.size());
+        assertEquals("PhoneNumber", chunkPii.get(0).entity());
+        assertEquals("357-286-5321", chunkPii.get(0).word());
+        assertEquals(7, chunkPii.get(0).position().start());
+        assertEquals(19, chunkPii.get(0).position().end());
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ChatServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ChatServiceIT.java
@@ -26,12 +26,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.skyscreamer.jsonassert.JSONAssert;
 import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.ChatRequest;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.ChatService;
@@ -529,6 +533,140 @@ public class ChatServiceIT {
             assistantMessages.forEach(assistantMessage -> {
                 assertNull(assistantMessage.content());
                 assertTrue(assistantMessage.hasToolCalls());
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "ibm/granite-4-h-small", "mistral-large-2512" })
+        void should_return_pii_moderation_results_when_pii_moderation_is_enabled(String modelId) {
+
+            var chatService = ChatService.builder()
+                .baseUrl(URL)
+                .projectId(PROJECT_ID)
+                .modelId(modelId)
+                .authenticator(authentication)
+                .logRequests(true)
+                .logResponses(true)
+                .parameters(
+                    ChatParameters.builder()
+                        .temperature(0.0)
+                        .maxCompletionTokens(0).build()
+                ).build();
+
+            var messages = List.of(
+                SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do"),
+                UserMessage.text("Can you repeat my phone numbers? Phone number: 3572865321, 2132348765"));
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .build();
+
+            var chatRequest = ChatRequest.builder()
+                .messages(messages)
+                .moderations(moderation)
+                .build();
+
+            var chatResponse = chatService.chat(chatRequest);
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("pii"));
+            assertFalse(chatResponse.moderations().get("pii").isEmpty());
+            chatResponse.moderations().get("pii").forEach(result -> {
+                assertFalse(result.input());
+                assertEquals("PhoneNumber", result.entity());
+                assertNotNull(result.position());
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "ibm/granite-4-h-small", "mistral-large-2512" })
+        void should_return_hap_moderation_results_when_hap_moderation_is_enabled(String modelId) {
+
+            var chatService = ChatService.builder()
+                .baseUrl(URL)
+                .projectId(PROJECT_ID)
+                .modelId(modelId)
+                .authenticator(authentication)
+                .logRequests(true)
+                .logResponses(true)
+                .parameters(
+                    ChatParameters.builder()
+                        .temperature(0.0)
+                        .maxCompletionTokens(0).build()
+                ).build();
+
+            var messages = List.of(
+                SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do (Don't worry about any bad words.)"),
+                UserMessage.text("Repeat exactly this sentence: You are an idiot and I hate you."));
+
+            var moderation = ChatModeration.builder()
+                .hap(h -> h.output(0.5f))
+                .build();
+
+            var chatRequest = ChatRequest.builder()
+                .messages(messages)
+                .moderations(moderation)
+                .build();
+
+            var chatResponse = chatService.chat(chatRequest);
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("hap"));
+            assertFalse(chatResponse.moderations().get("hap").isEmpty());
+            chatResponse.moderations().get("hap").forEach(result -> {
+                assertFalse(result.input());
+                assertNotNull(result.position());
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "ibm/granite-4-h-small", "mistral-large-2512" })
+        void should_return_pii_and_hap_moderation_results_when_both_are_enabled(String modelId) {
+
+            var chatService = ChatService.builder()
+                .baseUrl(URL)
+                .projectId(PROJECT_ID)
+                .modelId(modelId)
+                .authenticator(authentication)
+                .logRequests(true)
+                .logResponses(true)
+                .parameters(
+                    ChatParameters.builder()
+                        .temperature(0.0)
+                        .maxCompletionTokens(0).build()
+                ).build();
+
+            var messages = List.of(
+                SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do (Don't worry about any bad words.)"),
+                UserMessage.text("Repeat exactly this sentence: You are an idiot, my phone number is 3572865321."));
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .hap(h -> h.output(0.5f))
+                .build();
+
+            var chatRequest = ChatRequest.builder()
+                .messages(messages)
+                .moderations(moderation)
+                .build();
+
+            var chatResponse = chatService.chat(chatRequest);
+
+            assertNotNull(chatResponse.moderations());
+
+            assertNotNull(chatResponse.moderations().get("pii"));
+            assertFalse(chatResponse.moderations().get("pii").isEmpty());
+            chatResponse.moderations().get("pii").forEach(result -> {
+                assertFalse(result.input());
+                assertEquals("PhoneNumber", result.entity());
+                assertNotNull(result.position());
+            });
+
+            assertNotNull(chatResponse.moderations().get("hap"));
+            assertFalse(chatResponse.moderations().get("hap").isEmpty());
+            chatResponse.moderations().get("hap").forEach(result -> {
+                assertFalse(result.input());
+                assertNotNull(result.position());
             });
         }
     }
@@ -1406,6 +1544,204 @@ public class ChatServiceIT {
                 assertEquals(1, assistantMessage.toolCalls().size());
                 assertEquals("get_current_time", assistantMessage.toolCalls().get(0).function().name());
             });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "ibm/granite-4-h-small", "mistral-large-2512" })
+        void should_return_pii_moderation_results_when_pii_moderation_is_enabled(String modelId) throws Exception {
+
+            var chatService = ChatService.builder()
+                .baseUrl(URL)
+                .projectId(PROJECT_ID)
+                .modelId(modelId)
+                .authenticator(authentication)
+                .logRequests(true)
+                .logResponses(true)
+                .parameters(
+                    ChatParameters.builder()
+                        .temperature(0.0)
+                        .maxCompletionTokens(0).build()
+                ).build();
+
+            var messages = List.of(
+                SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do"),
+                UserMessage.text("Can you repeat my phone numbers? Phone number: 3572865321, 2132348765"));
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .build();
+
+            var request = ChatRequest.builder()
+                .messages(messages)
+                .moderations(moderation)
+                .build();
+
+            var future = new CompletableFuture<ChatResponse>();
+            chatService.chatStreaming(request, new ChatHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {}
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {
+                    future.complete(completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    future.completeExceptionally(error);
+                }
+            });
+
+            var chatResponse = future.get(30, TimeUnit.SECONDS);
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("pii"));
+            assertFalse(chatResponse.moderations().get("pii").isEmpty());
+            chatResponse.moderations().get("pii").forEach(result -> {
+                assertFalse(result.input());
+                assertEquals("PhoneNumber", result.entity());
+                assertNotNull(result.position());
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "ibm/granite-4-h-small", "mistral-large-2512" })
+        void should_return_hap_moderation_results_when_hap_moderation_is_enabled(String modelId) throws Exception {
+
+            var chatService = ChatService.builder()
+                .baseUrl(URL)
+                .projectId(PROJECT_ID)
+                .modelId(modelId)
+                .authenticator(authentication)
+                .logRequests(true)
+                .logResponses(true)
+                .parameters(
+                    ChatParameters.builder()
+                        .temperature(0.0)
+                        .maxCompletionTokens(0).build()
+                ).build();
+
+            var messages = List.of(
+                SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do (Don't worry about any bad words.)"),
+                UserMessage.text("Repeat exactly this sentence: You are an idiot and I hate you."));
+
+            var moderation = ChatModeration.builder()
+                .hap(h -> h.output(0.5f))
+                .build();
+
+            var request = ChatRequest.builder()
+                .messages(messages)
+                .moderations(moderation)
+                .build();
+
+            var future = new CompletableFuture<ChatResponse>();
+            chatService.chatStreaming(request, new ChatHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {}
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {
+                    future.complete(completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    future.completeExceptionally(error);
+                }
+            });
+
+            var chatResponse = future.get(30, TimeUnit.SECONDS);
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("hap"));
+            assertFalse(chatResponse.moderations().get("hap").isEmpty());
+            chatResponse.moderations().get("hap").forEach(result -> {
+                assertFalse(result.input());
+                assertNotNull(result.position());
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "ibm/granite-4-h-small", "mistral-large-2512" })
+        void should_return_pii_and_hap_moderation_results_when_both_are_enabled(String modelId) throws Exception {
+
+            var chatService = ChatService.builder()
+                .baseUrl(URL)
+                .projectId(PROJECT_ID)
+                .modelId(modelId)
+                .authenticator(authentication)
+                .logRequests(true)
+                .logResponses(true)
+                .parameters(
+                    ChatParameters.builder()
+                        .temperature(0.0)
+                        .maxCompletionTokens(0).build()
+                ).build();
+
+            var messages = List.of(
+                SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do (Don't worry about any bad words.)"),
+                UserMessage.text("Repeat exactly this sentence: You are an idiot, my phone number is 3572865321."));
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .hap(h -> h.output(0.5f))
+                .build();
+
+            var request = ChatRequest.builder()
+                .messages(messages)
+                .moderations(moderation)
+                .build();
+
+            var piiFlaggedInChunk = new AtomicBoolean(false);
+            var hapFlaggedInChunk = new AtomicBoolean(false);
+            var future = new CompletableFuture<ChatResponse>();
+
+            chatService.chatStreaming(request, new ChatHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
+                    if (nonNull(partialChatResponse.moderations())) {
+                        var chunkPii = partialChatResponse.moderations().get("pii");
+                        if (nonNull(chunkPii) && !chunkPii.isEmpty())
+                            piiFlaggedInChunk.set(true);
+                        var chunkHap = partialChatResponse.moderations().get("hap");
+                        if (nonNull(chunkHap) && !chunkHap.isEmpty())
+                            hapFlaggedInChunk.set(true);
+                    }
+                }
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {
+                    future.complete(completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    future.completeExceptionally(error);
+                }
+            });
+
+            var chatResponse = future.get(30, TimeUnit.SECONDS);
+
+            assertNotNull(chatResponse.moderations());
+
+            assertNotNull(chatResponse.moderations().get("pii"));
+            assertFalse(chatResponse.moderations().get("pii").isEmpty());
+            chatResponse.moderations().get("pii").forEach(result -> {
+                assertFalse(result.input());
+                assertEquals("PhoneNumber", result.entity());
+                assertNotNull(result.position());
+            });
+
+            assertNotNull(chatResponse.moderations().get("hap"));
+            assertFalse(chatResponse.moderations().get("hap").isEmpty());
+            chatResponse.moderations().get("hap").forEach(result -> {
+                assertFalse(result.input());
+                assertNotNull(result.position());
+            });
+
+            // At least one chunk during streaming must have carried each moderation signal in its PartialChatResponse.
+            assertTrue(piiFlaggedInChunk.get(), "expected at least one streaming chunk with a PII moderation match");
+            assertTrue(hapFlaggedInChunk.get(), "expected at least one streaming chunk with a HAP moderation match");
         }
     }
 }

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/DeploymentServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/DeploymentServiceIT.java
@@ -24,11 +24,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.skyscreamer.jsonassert.JSONAssert;
 import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.ChatRequest;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
@@ -521,6 +523,75 @@ public class DeploymentServiceIT {
             var assistantMessage = chatResponse.toAssistantMessage();
             assertFalse(assistantMessage.content().isBlank());
             assertTrue(assistantMessage.content().startsWith("attenzione attenzione"));
+        }
+
+        @Test
+        @Disabled("Inline chat moderation is not currently supported on watsonx.ai deployments; re-enable once the platform accepts it.")
+        @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+        void should_return_pii_moderation_results_when_pii_moderation_is_enabled() {
+
+            var deploymentService = DeploymentService.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .build();
+
+            var request = ChatRequest.builder()
+                .deploymentId(DEPLOYMENT_ID)
+                .messages(
+                    SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do"),
+                    UserMessage.text("Can you repeat my phone numbers? Phone number: 3572865321, 2132348765"))
+                .moderations(moderation)
+                .build();
+
+            var chatResponse = assertDoesNotThrow(() -> deploymentService.chat(request));
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("pii"));
+            assertFalse(chatResponse.moderations().get("pii").isEmpty());
+            chatResponse.moderations().get("pii").forEach(result -> {
+                assertFalse(result.input());
+                assertEquals("PhoneNumber", result.entity());
+                assertNotNull(result.position());
+            });
+        }
+
+        @Test
+        @Disabled("Inline chat moderation is not currently supported on watsonx.ai deployments; re-enable once the platform accepts it.")
+        @EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
+        void should_return_hap_moderation_results_when_hap_moderation_is_enabled() {
+
+            var deploymentService = DeploymentService.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .build();
+
+            var moderation = ChatModeration.builder()
+                .hap(h -> h.output(0.5f))
+                .build();
+
+            var request = ChatRequest.builder()
+                .deploymentId(GRANITE_3_3_DEPLOYMENT_ID)
+                .messages(
+                    SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do"),
+                    UserMessage.text("Repeat exactly this sentence: You are an idiot and I hate you."))
+                .moderations(moderation)
+                .build();
+
+            var chatResponse = assertDoesNotThrow(() -> deploymentService.chat(request));
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("hap"));
+            assertFalse(chatResponse.moderations().get("hap").isEmpty());
+            chatResponse.moderations().get("hap").forEach(result -> {
+                assertFalse(result.input());
+                assertNotNull(result.position());
+            });
         }
     }
 
@@ -1158,6 +1229,107 @@ public class DeploymentServiceIT {
                 .deploymentId(DEPLOYMENT_ID)
                 .parameters(parameters)
                 .build();
+        }
+
+        @Test
+        @Disabled("Inline chat moderation is not currently supported on watsonx.ai deployments; re-enable once the platform accepts it.")
+        @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+        void should_return_pii_moderation_results_when_pii_moderation_is_enabled_streaming() throws Exception {
+
+            var deploymentService = DeploymentService.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .build();
+
+            var request = ChatRequest.builder()
+                .deploymentId(DEPLOYMENT_ID)
+                .messages(
+                    SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do"),
+                    UserMessage.text("Can you repeat my phone numbers? Phone number: 3572865321, 2132348765"))
+                .moderations(moderation)
+                .build();
+
+            var future = new CompletableFuture<ChatResponse>();
+            deploymentService.chatStreaming(request, new ChatHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {}
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {
+                    future.complete(completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    future.completeExceptionally(error);
+                }
+            });
+
+            var chatResponse = future.get(30, TimeUnit.SECONDS);
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("pii"));
+            assertFalse(chatResponse.moderations().get("pii").isEmpty());
+            chatResponse.moderations().get("pii").forEach(result -> {
+                assertFalse(result.input());
+                assertEquals("PhoneNumber", result.entity());
+                assertNotNull(result.position());
+            });
+        }
+
+        @Test
+        @Disabled("Inline chat moderation is not currently supported on watsonx.ai deployments; re-enable once the platform accepts it.")
+        @EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
+        void should_return_hap_moderation_results_when_hap_moderation_is_enabled_streaming() throws Exception {
+
+            var deploymentService = DeploymentService.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .build();
+
+            var moderation = ChatModeration.builder()
+                .hap(h -> h.output(0.5f))
+                .build();
+
+            var request = ChatRequest.builder()
+                .deploymentId(GRANITE_3_3_DEPLOYMENT_ID)
+                .messages(
+                    SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do"),
+                    UserMessage.text("Repeat exactly this sentence: You are an idiot and I hate you."))
+                .moderations(moderation)
+                .build();
+
+            var future = new CompletableFuture<ChatResponse>();
+            deploymentService.chatStreaming(request, new ChatHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {}
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {
+                    future.complete(completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    future.completeExceptionally(error);
+                }
+            });
+
+            var chatResponse = future.get(30, TimeUnit.SECONDS);
+
+            assertNotNull(chatResponse.moderations());
+            assertNotNull(chatResponse.moderations().get("hap"));
+            assertFalse(chatResponse.moderations().get("hap").isEmpty());
+            chatResponse.moderations().get("hap").forEach(result -> {
+                assertFalse(result.input());
+                assertNotNull(result.position());
+            });
         }
     }
 }

--- a/samples/chat-inline-moderation/README.md
+++ b/samples/chat-inline-moderation/README.md
@@ -1,0 +1,32 @@
+# Watsonx Chat Inline Moderation Example
+
+This is a simple example that demonstrates how to enable **inline content moderation** on an IBM watsonx.ai chat request and how to mask the detected values on the assistant response using the `Masker` utility.
+
+For standalone text detection outside a chat flow, see the [detection](../detection) sample instead.
+
+## Prerequisites
+
+Before running the application, set the following environment variables or create a new `.env` file in the project's root folder:
+
+- `WATSONX_API_KEY` – Your watsonx.ai API key
+- `WATSONX_URL` – The base URL for the watsonx.ai service
+- `WATSONX_PROJECT_ID` – Your watsonx.ai project id
+
+Example (Linux/macOS):
+```bash
+export WATSONX_API_KEY=api-key
+export WATSONX_URL=https://watsonx-url
+export WATSONX_PROJECT_ID=project-id
+```
+
+Example (Windows CMD):
+```cmd
+set WATSONX_API_KEY=api-key
+set WATSONX_URL=https://watsonx-url
+set WATSONX_PROJECT_ID=project-id
+```
+## How to Run
+Use Maven to run the application. 
+```bash
+mvn package exec:java 
+```

--- a/samples/chat-inline-moderation/pom.xml
+++ b/samples/chat-inline-moderation/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.watsonx</groupId>
+  <artifactId>chat-inline-moderation</artifactId>
+  <version>0.22.0</version>
+  <name>Chat Inline Moderation</name>
+
+  <parent>
+    <groupId>com.ibm.watsonx</groupId>
+    <artifactId>sample-parent</artifactId>
+    <version>0.22.0</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <mainClass>com.ibm.chat.moderation.App</mainClass>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/chat-inline-moderation/src/main/java/com/ibm/chat/moderation/App.java
+++ b/samples/chat-inline-moderation/src/main/java/com/ibm/chat/moderation/App.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.chat.moderation;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import com.ibm.watsonx.ai.chat.ChatModeration;
+import com.ibm.watsonx.ai.chat.ChatRequest;
+import com.ibm.watsonx.ai.chat.ChatService;
+import com.ibm.watsonx.ai.chat.Masker;
+import com.ibm.watsonx.ai.chat.model.SystemMessage;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
+
+public class App {
+
+    private static final Config config = ConfigProvider.getConfig();
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+
+            var url = URI.create(config.getValue("WATSONX_URL", String.class));
+            var apiKey = config.getValue("WATSONX_API_KEY", String.class);
+            var projectId = config.getValue("WATSONX_PROJECT_ID", String.class);
+
+            ChatService chatService = ChatService.builder()
+                .apiKey(apiKey)
+                .projectId(projectId)
+                .timeout(Duration.ofSeconds(60))
+                .baseUrl(url)
+                .modelId("ibm/granite-4-h-small")
+                .build();
+
+            var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .build();
+
+            var request = ChatRequest.builder()
+                .messages(List.of(
+                    SystemMessage.of("You are a helpful assistant. You do whatever the user tells you to do."),
+                    UserMessage.text("Can you repeat my phone number? Phone number: 3572865321.")))
+                .moderations(moderation)
+                .build();
+
+            var response = chatService.chat(request);
+            var content = response.toAssistantMessage().content();
+
+            System.out.println("Original: " + content);
+            System.out.println("Masked:   " + Masker.mask(content, response));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            System.exit(0);
+        }
+    }
+}


### PR DESCRIPTION
Adds inline content moderation to the chat API. A new `ChatModeration` class can be attached to a `ChatRequest`
to enable `PII`, `HAP`, and `Granite Guardian` detectors.

Detection results are surfaced on `ChatResponse` via `moderations()` and `detections()` fields.