### PR TITLE
Add `EmptyChatResponseException` with finish reason and choice index

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The SDK provides a unified Java interface to the watsonx.ai ecosystem and works 
 | Service | Description |
 |---------|-------------|
 | **[Chat](https://ibm.github.io/watsonx-ai-java-sdk/services/chat-service/)** | Conversational AI with multi-turn dialogue, streaming, tool calling, vision, and reasoning |
-| **[Model Gateway](https://ibm.github.io/watsonx-ai-java-sdk/services/model-gateway/)** | Chat with third-party models (OpenAI, Anthropic, Azure, Mistral, and others) through a single IBM Cloud-authenticated endpoint |
+| **[Model Gateway](https://ibm.github.io/watsonx-ai-java-sdk/services/model-gateway/)** | Chat with third-party models |
 | **[Embedding](https://ibm.github.io/watsonx-ai-java-sdk/services/embedding-service/)** | Dense vector representations for semantic search, similarity, and RAG |
 | **[Rerank](https://ibm.github.io/watsonx-ai-java-sdk/services/rerank-service/)** | Relevance scoring and reordering of candidate documents |
 | **[Detection](https://ibm.github.io/watsonx-ai-java-sdk/services/detection-service/)** | Identification of harmful content (HAP), PII, and safety violations |

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
@@ -8,6 +8,7 @@ package com.ibm.watsonx.ai.chat;
 
 import static java.util.Objects.isNull;
 import java.util.List;
+import java.util.stream.IntStream;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
@@ -152,16 +153,31 @@ public class ChatResponse {
      * was made with the {@code n} parameter greater than 1 to retrieve multiple alternative responses from the model.
      *
      * @return a list of {@code AssistantMessage} instances, one for each choice in the response
+     * @throws EmptyChatResponseException if the response contains no choices, or if any choice contains no content, tool calls or refusal
      * @see #toAssistantMessage()
      */
     public List<AssistantMessage> toAssistantMessages() {
 
         if (isNull(choices) || choices.isEmpty())
-            throw new IllegalStateException("The chat response contains no choices");
+            throw new EmptyChatResponseException(
+                "The chat response contains no choices",
+                this,
+                FinishReason.INCOMPLETE,
+                EmptyChatResponseException.NO_CHOICE);
 
-        return choices.stream()
-            .map(ResultChoice::message)
-            .map(message -> {
+        return IntStream.range(0, choices.size())
+            .mapToObj(index -> {
+
+                var choice = choices.get(index);
+                var message = choice.message();
+                var finishReason = FinishReason.fromValue(choice.finishReason());
+
+                if (isNull(message))
+                    throw new EmptyChatResponseException(
+                        "The choice at index %s contains no message".formatted(index),
+                        this,
+                        finishReason,
+                        index);
 
                 String content;
                 String thinking;
@@ -174,6 +190,13 @@ public class ChatResponse {
                     content = isNull(content) ? message.content() : content;
                     thinking = extractionTags.extractThinking(message.content());
                 }
+
+                if (isNullOrBlank(content) && isNullOrBlank(message.refusal()) && (isNull(message.toolCalls()) || message.toolCalls().isEmpty()))
+                    throw new EmptyChatResponseException(
+                        "The model generated no content, tool calls or refusal (finish reason: %s)".formatted(finishReason),
+                        this,
+                        finishReason,
+                        index);
 
                 return new AssistantMessage(
                     content,
@@ -192,10 +215,21 @@ public class ChatResponse {
      * than 1, use {@link #toAssistantMessages()} instead to retrieve all alternative responses.
      *
      * @return an {@code AssistantMessage} containing the assistant's reply content from the first choice
+     * @throws EmptyChatResponseException if the response contains no choices, or if the first choice contains no content, tool calls or refusal
      * @see #toAssistantMessages()
      */
     public AssistantMessage toAssistantMessage() {
         return toAssistantMessages().get(0);
+    }
+
+    /**
+     * Checks whether the given value is {@code null} or contains only whitespace.
+     *
+     * @param value the value to check
+     * @return {@code true} if the value is {@code null} or blank, {@code false} otherwise
+     */
+    private static boolean isNullOrBlank(String value) {
+        return isNull(value) || value.isBlank();
     }
 
     /**

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/EmptyChatResponseException.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/EmptyChatResponseException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.chat;
+
+import com.ibm.watsonx.ai.chat.model.FinishReason;
+
+/**
+ * Exception thrown when a successful chat request returns a response without any usable output.
+ */
+public final class EmptyChatResponseException extends RuntimeException {
+
+    /** Value returned by {@link #index()} when the response contains no choices at all. */
+    public static final int NO_CHOICE = -1;
+
+    private final ChatResponse response;
+    private final FinishReason finishReason;
+    private final int index;
+
+    /**
+     * Constructs a new {@code EmptyChatResponseException}.
+     *
+     * @param message the detail message explaining the exception
+     * @param response the chat response that produced no usable output
+     * @param finishReason the finish reason of the empty choice
+     * @param index the index of the empty choice, or {@link #NO_CHOICE} if the response contains no choices
+     */
+    public EmptyChatResponseException(String message, ChatResponse response, FinishReason finishReason, int index) {
+        super(message);
+        this.response = response;
+        this.finishReason = finishReason;
+        this.index = index;
+    }
+
+    /**
+     * Returns the chat response that produced no usable output.
+     *
+     * @return the {@link ChatResponse}
+     */
+    public ChatResponse response() {
+        return response;
+    }
+
+    /**
+     * Returns the finish reason of the empty choice.
+     *
+     * @return the {@link FinishReason} of the empty choice, or {@link FinishReason#INCOMPLETE} if the response contains no choices
+     */
+    public FinishReason finishReason() {
+        return finishReason;
+    }
+
+    /**
+     * Returns the index of the empty choice.
+     *
+     * @return the index of the empty choice, or {@link #NO_CHOICE} if the response contains no choices
+     */
+    public int index() {
+        return index;
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/AssistantMessage.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/AssistantMessage.java
@@ -16,8 +16,8 @@ import com.ibm.watsonx.ai.core.spi.json.TypeToken;
 /**
  * Represents a message authored by the assistant within a chat interaction.
  * <p>
- * An {@code AssistantMessage} may contain natural language text or tool calls (e.g., function calls). Either {@code content} or {@code toolCalls}
- * must be present.
+ * An {@code AssistantMessage} may contain natural language text or tool calls (e.g., function calls). At least one of {@code content},
+ * {@code toolCalls} or {@code refusal} must be present.
  * <p>
  * Example usage:
  *

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/Thinking.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/Thinking.java
@@ -155,6 +155,50 @@ public final class Thinking {
         }
     }
 
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        Boolean resolvedEnabled = enabled();
+        result = prime * result + ((resolvedEnabled == null) ? 0 : resolvedEnabled.hashCode());
+        result = prime * result + ((includeReasoning == null) ? 0 : includeReasoning.hashCode());
+        result = prime * result + ((extractionTags == null) ? 0 : extractionTags.hashCode());
+        result = prime * result + ((thinkingEffort == null) ? 0 : thinkingEffort.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Thinking other = (Thinking) obj;
+        Boolean resolvedEnabled = enabled();
+        Boolean otherResolvedEnabled = other.enabled();
+        if (resolvedEnabled == null) {
+            if (otherResolvedEnabled != null)
+                return false;
+        } else if (!resolvedEnabled.equals(otherResolvedEnabled))
+            return false;
+        if (includeReasoning == null) {
+            if (other.includeReasoning != null)
+                return false;
+        } else if (!includeReasoning.equals(other.includeReasoning))
+            return false;
+        if (extractionTags == null) {
+            if (other.extractionTags != null)
+                return false;
+        } else if (!extractionTags.equals(other.extractionTags))
+            return false;
+        if (thinkingEffort != other.thinkingEffort)
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
         return "Thinking [enabled=" + enabled + ", includeReasoning=" + includeReasoning + ", extractionTags=" + extractionTags + ", thinkingEffort="

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ChatResponseTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ChatResponseTest.java
@@ -6,13 +6,23 @@ package com.ibm.watsonx.ai.chat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionEntry;
 import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionResult;
 import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
 import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult.Position;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
+import com.ibm.watsonx.ai.chat.model.FinishReason;
+import com.ibm.watsonx.ai.chat.model.ResultMessage;
+import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
 
 public class ChatResponseTest {
@@ -44,6 +54,19 @@ public class ChatResponseTest {
             .serviceTier("default")
             .systemFingerprint("fp_abc123")
             .cached(false);
+    }
+
+    private static ChatResponse singleChoiceResponse(ResultMessage message, String finishReason) {
+        return ChatResponse.builder()
+            .id("chat-1")
+            .object("chat.completion")
+            .model("ibm/granite-3-3-8b-instruct")
+            .choices(List.of(new ResultChoice(0, message, finishReason)))
+            .build();
+    }
+
+    private static ResultMessage resultMessage(String content, String reasoningContent, String refusal, List<ToolCall> toolCalls) {
+        return new ResultMessage("assistant", content, reasoningContent, refusal, toolCalls);
     }
 
     @Test
@@ -104,5 +127,122 @@ public class ChatResponseTest {
         assertNotEquals(textChatResponse, chatResponse);
         assertNotEquals(textChatResponse, gatewayChatResponse);
         assertNotEquals(gatewayChatResponse, textChatResponse);
+    }
+
+    @Test
+    void should_throw_when_the_response_contains_no_choices() {
+
+        var noChoices = ChatResponse.builder().id("chat-1").build();
+
+        var ex = assertThrows(EmptyChatResponseException.class, noChoices::toAssistantMessage);
+        assertEquals("The chat response contains no choices", ex.getMessage());
+        assertEquals(FinishReason.INCOMPLETE, ex.finishReason());
+        assertEquals(EmptyChatResponseException.NO_CHOICE, ex.index());
+        assertSame(noChoices, ex.response());
+
+        var emptyChoices = ChatResponse.builder().id("chat-1").choices(List.of()).build();
+        assertThrows(EmptyChatResponseException.class, emptyChoices::toAssistantMessages);
+    }
+
+    @Test
+    void should_throw_when_the_model_generates_no_usable_output() {
+
+        for (String content : new String[] { null, "", "   ", "\n" }) {
+
+            var response = singleChoiceResponse(resultMessage(content, null, null, null), "stop");
+
+            var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+            assertEquals("The model generated no content, tool calls or refusal (finish reason: STOP)", ex.getMessage());
+            assertEquals(FinishReason.STOP, ex.finishReason());
+            assertEquals(0, ex.index());
+            assertSame(response, ex.response());
+        }
+    }
+
+    @Test
+    void should_throw_when_the_tool_calls_are_empty() {
+        var response = singleChoiceResponse(resultMessage("", null, null, List.of()), "stop");
+        assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+    }
+
+    @Test
+    void should_throw_when_only_the_thinking_is_present() {
+
+        var response = singleChoiceResponse(resultMessage(null, "The user is asking for", null, null), "length");
+
+        var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+        assertEquals(FinishReason.LENGTH, ex.finishReason());
+    }
+
+    @Test
+    void should_throw_when_the_choice_contains_no_message() {
+
+        var response = ChatResponse.builder().choices(List.of(new ResultChoice(0, null, "stop"))).build();
+
+        var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+        assertEquals("The choice at index 0 contains no message", ex.getMessage());
+    }
+
+    @Test
+    void should_throw_when_the_extraction_tags_leave_no_response() {
+
+        var response = ChatResponse.builder()
+            .extractionTags(ExtractionTags.of(new Think("<think>", "</think>")))
+            .choices(List.of(new ResultChoice(0, resultMessage("<think>Only reasoning</think>", null, null, null), "stop")))
+            .build();
+
+        var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+        assertEquals(FinishReason.STOP, ex.finishReason());
+    }
+
+    @Test
+    void should_report_the_finish_reason_and_the_index_of_the_empty_choice() {
+
+        var response = ChatResponse.builder()
+            .choices(List.of(
+                new ResultChoice(0, resultMessage("First answer", null, null, null), "stop"),
+                new ResultChoice(1, resultMessage(null, null, null, null), "length")))
+            .build();
+
+        var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessages);
+        assertEquals(1, ex.index());
+        assertEquals(FinishReason.LENGTH, ex.finishReason());
+    }
+
+    @Test
+    void should_convert_when_the_refusal_is_the_only_output() {
+
+        var response = singleChoiceResponse(resultMessage(null, null, "I cannot help with that", null), "stop");
+
+        var assistantMessage = response.toAssistantMessage();
+        assertNull(assistantMessage.content());
+        assertEquals("I cannot help with that", assistantMessage.refusal());
+    }
+
+    @Test
+    void should_convert_when_the_tool_calls_are_the_only_output() {
+
+        var toolCalls = List.of(ToolCall.of("call-1", "get_weather", "{\"city\":\"Rome\"}"));
+        var response = singleChoiceResponse(resultMessage(null, null, null, toolCalls), "tool_calls");
+
+        var assistantMessage = response.toAssistantMessage();
+        assertNull(assistantMessage.content());
+        assertTrue(assistantMessage.hasToolCalls());
+    }
+
+    @Test
+    void should_convert_every_choice_when_all_of_them_have_content() {
+
+        var response = ChatResponse.builder()
+            .choices(List.of(
+                new ResultChoice(0, resultMessage("First answer", null, null, null), "stop"),
+                new ResultChoice(1, resultMessage("Second answer", "The user is asking for", null, null), "stop")))
+            .build();
+
+        var assistantMessages = response.toAssistantMessages();
+        assertEquals(2, assistantMessages.size());
+        assertEquals("First answer", assistantMessages.get(0).content());
+        assertEquals("Second answer", assistantMessages.get(1).content());
+        assertEquals("The user is asking for", assistantMessages.get(1).thinking());
     }
 }

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/SseEventProcessorTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/SseEventProcessorTest.java
@@ -7,6 +7,8 @@ package com.ibm.watsonx.ai.chat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.stream.Stream;
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import com.ibm.watsonx.ai.chat.SseEventProcessor.CallbackEvent.CompleteToolCallEvent;
 import com.ibm.watsonx.ai.chat.SseEventProcessor.CallbackEvent.PartialResponseEvent;
 import com.ibm.watsonx.ai.chat.SseEventProcessor.CallbackEvent.PartialThinkingEvent;
+import com.ibm.watsonx.ai.chat.model.FinishReason;
 
 public class SseEventProcessorTest {
 
@@ -278,5 +281,61 @@ public class SseEventProcessorTest {
             var expectedTools = choice.index() == 0 ? 2 : 1;
             assertEquals(expectedTools, choice.message().toolCalls().size());
         }
+    }
+
+    @Test
+    void should_throw_when_the_stream_carries_no_usable_output() {
+
+        var processor = new SseEventProcessor(List.of(), null, TextChatResponse::builder);
+
+        var roleChunk = "data: " + """
+            {"id":"chatcmpl-6","object":"chat.completion.chunk","model_id":"ibm/granite-4-h-small","model":"ibm/granite-4-h-small",\
+            "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":""}}],\
+            "created":1,"created_at":"2026-07-26T00:00:00.000Z"}""";
+
+        var stopChunk = "data: " + """
+            {"id":"chatcmpl-6","object":"chat.completion.chunk","model_id":"ibm/granite-4-h-small","model":"ibm/granite-4-h-small",\
+            "choices":[{"index":0,"finish_reason":"stop","delta":{"role":"assistant"}}],\
+            "created":1,"created_at":"2026-07-26T00:00:00.001Z"}""";
+
+        processor.processChunk(roleChunk);
+        processor.processChunk(stopChunk);
+
+        var response = processor.buildResponse();
+
+        // The choice exists, only its content is empty.
+        assertEquals(1, response.choices().size());
+        assertNull(response.choices().get(0).message().content());
+
+        var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+        assertEquals("The model generated no content, tool calls or refusal (finish reason: STOP)", ex.getMessage());
+        assertEquals(FinishReason.STOP, ex.finishReason());
+        assertEquals(0, ex.index());
+    }
+
+    @Test
+    void should_throw_when_the_stream_is_truncated_while_the_model_is_thinking() {
+
+        var processor = new SseEventProcessor(List.of(), null, TextChatResponse::builder);
+
+        var thinkingChunk = "data: " + """
+            {"id":"chatcmpl-7","object":"chat.completion.chunk","model_id":"openai/gpt-oss-120b","model":"openai/gpt-oss-120b",\
+            "choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","reasoning_content":"The user is asking for"}}],\
+            "created":1,"created_at":"2026-07-26T00:00:00.000Z"}""";
+
+        var lengthChunk = "data: " + """
+            {"id":"chatcmpl-7","object":"chat.completion.chunk","model_id":"openai/gpt-oss-120b","model":"openai/gpt-oss-120b",\
+            "choices":[{"index":0,"finish_reason":"length","delta":{"role":"assistant"}}],\
+            "created":1,"created_at":"2026-07-26T00:00:00.001Z"}""";
+
+        processor.processChunk(thinkingChunk);
+        processor.processChunk(lengthChunk);
+
+        var response = processor.buildResponse();
+        assertEquals("The user is asking for", response.choices().get(0).message().reasoningContent());
+
+        var ex = assertThrows(EmptyChatResponseException.class, response::toAssistantMessage);
+        assertEquals(FinishReason.LENGTH, ex.finishReason());
+        assertEquals(0, ex.index());
     }
 }


### PR DESCRIPTION
Replace the generic `IllegalStateException` thrown by `toAssistantMessages()` with a dedicated `EmptyChatResponseException` that carries the finish reason, the choice index, and the original `ChatResponse`, making it easier for callers to distinguish truncated or refused responses from unexpected errors.