### PR TITLE
Add ClusterSchema API support for document schema clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The SDK provides a unified Java interface to the watsonx.ai ecosystem and works 
 | **[Detection](https://ibm.github.io/watsonx-ai-java-sdk/services/detection-service/)** | Identification of harmful content (HAP), PII, and safety violations |
 | **[Tokenization](https://ibm.github.io/watsonx-ai-java-sdk/services/tokenization-service/)** | Token counting and analysis for any model |
 | **[Foundation Model](https://ibm.github.io/watsonx-ai-java-sdk/services/foundation-model-service/)** | Browse and query the watsonx.ai model catalog |
-| **[Schema](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/schema/)** | Create, improve, and merge document schemas |
+| **[Schema](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/schema/)** | Create, improve, merge, and cluster document schemas |
 | **[Text Classification](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/text-classification-service/)** | Document classification from IBM Cloud Object Storage |
 | **[Text Extraction](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/text-extraction-service/)** | Structured data extraction from documents in IBM Cloud Object Storage |
 | **[Time Series](https://ibm.github.io/watsonx-ai-java-sdk/services/time-series-service/)** | Time series forecasting using IBM Granite TTM models |

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -72,6 +72,7 @@ System.out.println(response.content());
 | **[Create Schema](services/document-processing/schema/create-schema-service)** | Generate a key-value extraction schema from sample documents |
 | **[Improve Schema](services/document-processing/schema/improve-schema-service)** | Refine an existing schema using additional examples |
 | **[Merge Schema](services/document-processing/schema/merge-schema-service)** | Consolidate multiple schemas into one |
+| **[Cluster Schema](services/document-processing/schema/cluster-schema-service)** | Group a set of schemas into semantically similar clusters |
 | **[Text Extraction](services/document-processing/text-extraction-service)** | Extract structured key-value pairs from documents in COS |
 | **[Text Classification](services/document-processing/text-classification-service)** | Classify documents stored in COS |
 

--- a/docs/content/services/document-processing/schema/cluster-schema-service.md
+++ b/docs/content/services/document-processing/schema/cluster-schema-service.md
@@ -1,0 +1,255 @@
+---
+id: cluster-schema-service
+title: Cluster
+---
+
+# Cluster Schema Service
+
+The `ClusterSchemaService` groups a set of custom document schemas into semantically similar clusters. It sends the schemas to the watsonx.ai clustering API and returns each cluster as a list of `ClusterSchemas` objects, letting you discover which document types are semantically related.
+
+## Quick Start
+
+```java
+ClusterSchemaService service = ClusterSchemaService.builder()
+    .apiKey(WATSONX_API_KEY)
+    .projectId(WATSONX_PROJECT_ID)
+    .baseUrl(CloudRegion.DALLAS)
+    .build();
+
+ClusterSchemas passport = new ClusterSchemas("Passport",
+    Schema.builder()
+        .documentType("Passport")
+        .documentDescription("A government-issued travel document")
+        .fields(KvpFields.builder()
+            .add("surname",     KvpField.of("The holder's last name", "SMITH"))
+            .add("given_names", KvpField.of("The holder's first names", "ALICE MARIE"))
+            .build())
+        .build());
+
+ClusterSchemas nationalId = new ClusterSchemas("National_ID",
+    Schema.builder()
+        .documentType("National ID Card")
+        .documentDescription("A government-issued national identity document")
+        .fields(KvpFields.builder()
+            .add("surname",     KvpField.of("The holder's family name", "DOE"))
+            .add("given_names", KvpField.of("The holder's first names", "JOHN JAMES"))
+            .build())
+        .build());
+
+List<List<ClusterSchemas>> groups = service.clusterSchemaAndFetch(passport, nationalId);
+
+for (List<ClusterSchemas> cluster : groups) {
+    System.out.println("Cluster:");
+    cluster.forEach(s -> System.out.println("  - " + s.documentName()));
+}
+// → Cluster:
+// →   - Passport
+// →   - National_ID
+```
+
+---
+
+## Overview
+
+The `ClusterSchemaService` enables you to:
+
+- Group semantically similar document schemas into clusters automatically.
+- Identify which document types share common fields and structure.
+- Prepare input for schema consolidation workflows before merging.
+- Optionally override the default foundation model used for clustering.
+
+---
+
+## Service Configuration
+
+### Basic Setup
+
+```java
+ClusterSchemaService service = ClusterSchemaService.builder()
+    .apiKey(WATSONX_API_KEY)
+    .projectId(WATSONX_PROJECT_ID)
+    .baseUrl(CloudRegion.DALLAS)
+    .build();
+```
+
+### Builder Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `apiKey` | String | Conditional | API key for IBM Cloud authentication |
+| `authenticator` | Authenticator | Conditional | Custom authentication (alternative to `apiKey`) |
+| `projectId` | String | Conditional | Project ID where clustering will be performed |
+| `spaceId` | String | Conditional | Space ID (alternative to `projectId`) |
+| `baseUrl` | String/CloudRegion | Yes | watsonx.ai service base URL |
+| `timeout` | Duration | No | Request timeout (default: 60 seconds) |
+| `logRequests` | Boolean | No | Enable request logging (default: false) |
+| `logResponses` | Boolean | No | Enable response logging (default: false) |
+| `httpClient` | HttpClient | No | Custom HTTP client |
+| `verifySsl` | Boolean | No | SSL certificate verification (default: true) |
+| `version` | String | No | API version override |
+
+> Either `apiKey` or `authenticator` must be provided. Either `projectId` or `spaceId` must be specified.
+
+---
+
+## Examples
+
+### Cluster and Fetch in One Call
+
+`clusterSchemaAndFetch` submits the request, polls until completion, and returns the grouped result directly:
+
+```java
+List<List<ClusterSchemas>> groups = service.clusterSchemaAndFetch(passport, nationalId, invoice);
+
+for (List<ClusterSchemas> cluster : groups) {
+    System.out.println("Cluster: " +
+        cluster.stream().map(ClusterSchemas::documentName).collect(Collectors.joining(", ")));
+}
+// → Cluster: Passport, National_ID
+// → Cluster: Invoice
+```
+
+### With a List of Schemas
+
+Pass a `List` instead of varargs when the schemas are already collected:
+
+```java
+List<ClusterSchemas> schemas = buildSchemas(); // your own list
+List<List<ClusterSchemas>> groups = service.clusterSchemaAndFetch(schemas);
+```
+
+### With Custom Parameters
+
+Override project/space context or specify a custom semantic model:
+
+```java
+ClusterSchemaParameters parameters = ClusterSchemaParameters.builder()
+    .projectId("other-project-id")
+    .semanticConfig(
+        ClusterSchemaSemanticConfig.builder()
+            .defaultModelName("mistralai/mistral-medium-2505")
+            .build()
+    )
+    .build();
+
+List<List<ClusterSchemas>> groups =
+    service.clusterSchemaAndFetch(parameters, passport, nationalId);
+```
+
+### Async: Start Then Poll
+
+Use `startClusterSchema` to submit the job without waiting, then retrieve results later:
+
+```java
+// Submit the job
+ClusterSchemaResponse response = service.startClusterSchema(passport, nationalId);
+String jobId = response.metadata().id();
+
+// … do other work …
+
+// Retrieve the result
+ClusterSchemaResponse result = service.fetchRequest(jobId);
+System.out.println("Status: " + result.entity().results().status());
+
+if (Status.COMPLETED.value().equals(result.entity().results().status())) {
+    result.entity().results().schemas()
+        .forEach(cluster -> System.out.println("Cluster: " +
+            cluster.stream().map(ClusterSchemas::documentName)
+                   .collect(Collectors.joining(", "))));
+}
+```
+
+### Managing Requests
+
+Cancel or remove a cluster schema job:
+
+```java
+ClusterSchemaResponse response = service.startClusterSchema(passport, nationalId);
+
+boolean deleted = service.deleteRequest(
+    response.metadata().id(),
+    ClusterSchemaDeleteParameters.builder()
+        .hardDelete(true)
+        .build()
+);
+
+System.out.println("Deleted: " + deleted);
+// → Deleted: true
+```
+
+> Deleting a non-existent ID returns `false`.
+
+---
+
+## Cluster Schema Parameters
+
+`ClusterSchemaParameters` controls optional per-request overrides.
+
+### Builder Reference
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `schemas` | List&lt;ClusterSchemas&gt; | Override the list of schemas to cluster for this request |
+| `semanticConfig` | ClusterSchemaSemanticConfig | Semantic model configuration |
+| `projectId` | String | Override the default Project ID |
+| `spaceId` | String | Override the default Space ID |
+| `transactionId` | String | Request tracking ID |
+
+### Using a Custom Foundation Model
+
+Override the default clustering model with `defaultModelName`:
+
+```java
+ClusterSchemaSemanticConfig semanticConfig = ClusterSchemaSemanticConfig.builder()
+    .defaultModelName("ibm/granite-4-h-small")
+    .build();
+
+ClusterSchemaParameters parameters = ClusterSchemaParameters.builder()
+    .semanticConfig(semanticConfig)
+    .build();
+
+List<List<ClusterSchemas>> groups =
+    service.clusterSchemaAndFetch(parameters, passport, nationalId);
+```
+
+---
+
+## ClusterSchemaResponse
+
+Returned by `startClusterSchema` and `fetchRequest`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `metadata().id()` | String | Unique identifier for the cluster schema request |
+| `metadata().createdAt()` | String | Timestamp when the request was created |
+| `metadata().projectId()` | String | Project ID associated with the request |
+| `entity().parameters()` | Parameters | Parameters used for this clustering |
+| `entity().results()` | ClusterSchemaResult | The current clustering result |
+
+### ClusterSchemaResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status()` | String | Current status: `Status.SUBMITTED`, `Status.RUNNING`, `Status.COMPLETED`, or `Status.FAILED` (use `Status.COMPLETED.value()` to compare) |
+| `runningAt()` | String | Timestamp when processing started |
+| `completedAt()` | String | Timestamp when processing completed or failed |
+| `schemas()` | List&lt;List&lt;ClusterSchemas&gt;&gt; | The clusters - each inner list contains the schemas grouped together |
+| `error()` | Error | Error details if status is `failed` |
+
+### ClusterSchemas
+
+Each entry in a cluster:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `documentName()` | String | The name identifying this schema entry |
+| `schema()` | Schema | The full schema definition |
+
+---
+
+## Related Resources
+
+- [Create Schema Service](./create-schema-service) - Auto-generate schemas from documents
+- [Improve Schema Service](./improve-schema-service) - Refine existing schemas
+- [Merge Schema Service](./merge-schema-service) - Combine multiple schemas into one
+- [Cluster Schema API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#cluster-schema)

--- a/docs/content/services/document-processing/schema/index.md
+++ b/docs/content/services/document-processing/schema/index.md
@@ -2,8 +2,14 @@
 id: index
 title: Schema Services
 ---
----
 
 # Schema Services
 
 Schema Services provide functionality for working with document schemas in `watsonx.ai`. These services enable you to automatically generate, manage, and manipulate structured field definitions from documents, which can then be used for downstream [Text Extraction](../text-extraction-service) and [Text Classification](../text-classification-service) tasks.
+
+| Service | Description |
+|---------|-------------|
+| [Create Schema](./create-schema-service) | Automatically generate a document schema from a file |
+| [Improve Schema](./improve-schema-service) | Refine and enrich an existing schema from additional documents |
+| [Merge Schema](./merge-schema-service) | Combine multiple schemas into a single unified schema |
+| [Cluster Schema](./cluster-schema-service) | Group a set of schemas into semantically similar clusters |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -41,9 +41,10 @@ const sidebars: SidebarsConfig = {
               link: { type: 'doc', id: 'services/document-processing/schema/index' },
               collapsed: true,
               items: [
-                { type: 'doc', id: 'services/document-processing/schema/create-schema-service',  label: 'Create Schema' },
-                { type: 'doc', id: 'services/document-processing/schema/improve-schema-service', label: 'Improve Schema' },
-                { type: 'doc', id: 'services/document-processing/schema/merge-schema-service',   label: 'Merge Schema' },
+                { type: 'doc', id: 'services/document-processing/schema/create-schema-service',   label: 'Create Schema' },
+                { type: 'doc', id: 'services/document-processing/schema/improve-schema-service',  label: 'Improve Schema' },
+                { type: 'doc', id: 'services/document-processing/schema/merge-schema-service',    label: 'Merge Schema' },
+                { type: 'doc', id: 'services/document-processing/schema/cluster-schema-service',  label: 'Cluster Schema' },
               ],
             },
             { type: 'doc', id: 'services/document-processing/text-extraction-service',  label: 'Text Extraction' },

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/SemanticConfig.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/SemanticConfig.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.watsonx.ai.textprocessing;
 
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaSemanticConfig;
 import com.ibm.watsonx.ai.textprocessing.schema.create.CreateSchemaSemanticConfig;
 import com.ibm.watsonx.ai.textprocessing.schema.improve.ImproveSchemaSemanticConfig;
 import com.ibm.watsonx.ai.textprocessing.schema.merge.MergeSchemaSemanticConfig;
@@ -18,6 +19,7 @@ import com.ibm.watsonx.ai.textprocessing.textextraction.TextExtractionSemanticCo
  * @see CreateSchemaSemanticConfig
  * @see ImproveSchemaSemanticConfig
  * @see MergeSchemaSemanticConfig
+ * @see ClusterSchemaSemanticConfig
  */
 public abstract class SemanticConfig {
     private final String defaultModelName;

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaDeleteParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaDeleteParameters.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import java.util.Optional;
+import com.ibm.watsonx.ai.WatsonxParameters;
+
+/**
+ * Represents a set of parameters used to control the behavior of a cluster schema delete operation.
+ * <p>
+ * Instances of this class are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ClusterSchemaDeleteParameters.builder()
+ *     .projectId("project-id")
+ *     .hardDelete(true)
+ *     .build();
+ * }</pre>
+ *
+ */
+public final class ClusterSchemaDeleteParameters extends WatsonxParameters {
+    private final Optional<Boolean> hardDelete;
+
+    private ClusterSchemaDeleteParameters(Builder builder) {
+        super(builder);
+        this.hardDelete = Optional.ofNullable(builder.hardDelete);
+    }
+
+    /**
+     * Gets the hard delete option.
+     *
+     * @return an Optional containing true if hard delete is enabled
+     */
+    public Optional<Boolean> hardDelete() {
+        return hardDelete;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ClusterSchemaDeleteParameters.builder()
+     *     .projectId("project-id")
+     *     .hardDelete(true)
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link ClusterSchemaDeleteParameters} instances.
+     */
+    public static class Builder extends WatsonxParameters.Builder<Builder> {
+        private Boolean hardDelete;
+
+        private Builder() {}
+
+        /**
+         * Sets the hard delete option.
+         *
+         * @param hardDelete {@code true} to also delete job metadata
+         */
+        public Builder hardDelete(Boolean hardDelete) {
+            this.hardDelete = hardDelete;
+            return this;
+        }
+
+        /**
+         * Builds a {@link ClusterSchemaDeleteParameters} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ClusterSchemaDeleteParameters}
+         */
+        public ClusterSchemaDeleteParameters build() {
+            return new ClusterSchemaDeleteParameters(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterSchemaDeleteParameters [" + super.toString() + ", hardDelete=" + hardDelete + "]";
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaException.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+/**
+ * Exception thrown when an error occurs during cluster schema operations.
+ */
+public class ClusterSchemaException extends RuntimeException {
+
+    private final String code;
+
+    /**
+     * Constructs a new ClusterSchemaException with the specified error code and message.
+     *
+     * @param code the error code
+     * @param message the error message
+     */
+    public ClusterSchemaException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    /**
+     * Constructs a new ClusterSchemaException with the specified error code, message, and cause.
+     *
+     * @param code the error code
+     * @param message the error message
+     * @param cause the cause of the exception
+     */
+    public ClusterSchemaException(String code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    /**
+     * Returns the error code associated with this exception.
+     *
+     * @return the error code
+     */
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterSchemaException [code=%s, message=%s]".formatted(code, getMessage());
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaFetchParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaFetchParameters.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import com.ibm.watsonx.ai.WatsonxParameters;
+
+/**
+ * Represents a set of parameters used to control the behavior of a cluster schema fetch operation.
+ * <p>
+ * Instances of this class are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ClusterSchemaFetchParameters.builder()
+ *     .projectId("project-id")
+ *     .build();
+ * }</pre>
+ *
+ */
+public final class ClusterSchemaFetchParameters extends WatsonxParameters {
+
+    private ClusterSchemaFetchParameters(Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ClusterSchemaFetchParameters.builder()
+     *     .projectId("project-id")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link ClusterSchemaFetchParameters} instances.
+     */
+    public static class Builder extends WatsonxParameters.Builder<Builder> {
+
+        private Builder() {}
+
+        /**
+         * Builds a {@link ClusterSchemaFetchParameters} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ClusterSchemaFetchParameters}
+         */
+        public ClusterSchemaFetchParameters build() {
+            return new ClusterSchemaFetchParameters(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterSchemaFetchParameters [" + super.toString() + "]";
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaParameters.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import static java.util.Objects.isNull;
+import java.util.Arrays;
+import java.util.List;
+import com.ibm.watsonx.ai.WatsonxParameters;
+
+/**
+ * Represents a set of parameters used to control the behavior of a cluster schema operation.
+ * <p>
+ * Instances of this class are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ClusterSchemaParameters.builder()
+ *     .schemas(schema1, schema2)
+ *     .build();
+ * }</pre>
+ *
+ */
+public final class ClusterSchemaParameters extends WatsonxParameters {
+    private final List<ClusterSchemas> schemas;
+    private final ClusterSchemaSemanticConfig semanticConfig;
+
+    private ClusterSchemaParameters(Builder builder) {
+        super(builder);
+        this.schemas = isNull(builder.schemas) ? null : List.copyOf(builder.schemas);
+        this.semanticConfig = builder.semanticConfig;
+    }
+
+    /**
+     * Gets the list of document schemas to cluster.
+     *
+     * @return the list of cluster schemas
+     */
+    public List<ClusterSchemas> schemas() {
+        return schemas;
+    }
+
+    /**
+     * Gets the semantic configuration.
+     *
+     * @return the semantic configuration
+     */
+    public ClusterSchemaSemanticConfig semanticConfig() {
+        return semanticConfig;
+    }
+
+    /**
+     * Converts this parameters object to a {@link Parameters} record for API requests.
+     *
+     * @return a Parameters record containing the configuration
+     */
+    public Parameters toParameters() {
+        Parameters.SemanticConfig semanticConfigRecord = null;
+        if (semanticConfig != null)
+            semanticConfigRecord = new Parameters.SemanticConfig(semanticConfig.defaultModelName());
+        return new Parameters(schemas, semanticConfigRecord);
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ClusterSchemaParameters.builder()
+     *     .schemas(schema1, schema2)
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link ClusterSchemaParameters} instances.
+     */
+    public static class Builder extends WatsonxParameters.Builder<Builder> {
+        private List<ClusterSchemas> schemas;
+        private ClusterSchemaSemanticConfig semanticConfig;
+
+        private Builder() {}
+
+        /**
+         * Sets the list of document schemas to cluster.
+         *
+         * @param schemas one or more cluster schema entries
+         */
+        public Builder schemas(ClusterSchemas... schemas) {
+            this.schemas = Arrays.asList(schemas);
+            return this;
+        }
+
+        /**
+         * Sets the list of document schemas to cluster.
+         *
+         * @param schemas list of cluster schema entries
+         */
+        public Builder schemas(List<ClusterSchemas> schemas) {
+            this.schemas = schemas;
+            return this;
+        }
+
+        /**
+         * Sets the semantic configuration.
+         *
+         * @param semanticConfig the semantic configuration
+         */
+        public Builder semanticConfig(ClusterSchemaSemanticConfig semanticConfig) {
+            this.semanticConfig = semanticConfig;
+            return this;
+        }
+
+        /**
+         * Builds a {@link ClusterSchemaParameters} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ClusterSchemaParameters}
+         */
+        public ClusterSchemaParameters build() {
+            return new ClusterSchemaParameters(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterSchemaParameters [" + super.toString() + ", schemas=" + schemas + ", semanticConfig=" + semanticConfig + "]";
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+/**
+ * Represents a request for the Cluster Schema API.
+ *
+ * @param projectId the project identifier
+ * @param spaceId the space identifier
+ * @param parameters the parameters containing the schemas to cluster
+ */
+public record ClusterSchemaRequest(String projectId, String spaceId, Parameters parameters) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import java.util.List;
+import com.ibm.watsonx.ai.textprocessing.Error;
+import com.ibm.watsonx.ai.textprocessing.Metadata;
+
+/**
+ * Represents a response for the Cluster Schema API.
+ *
+ * @param metadata metadata associated with the response
+ * @param entity the cluster schema entity
+ */
+public record ClusterSchemaResponse(Metadata metadata, Entity entity) {
+
+    /**
+     * Represents the full cluster schema entity.
+     *
+     * @param parameters the parameters used for this cluster schema process
+     * @param results the current status and results of the cluster schema process
+     */
+    public record Entity(Parameters parameters, ClusterSchemaResult results) {}
+
+    /**
+     * Represents the result and status of a cluster schema process.
+     *
+     * @param status the status of the request
+     * @param runningAt the time when processing started
+     * @param completedAt the time when the request completed or failed
+     * @param schemas the schemas after being clustered, grouped into semantically similar clusters
+     * @param error optional error details in case of failure
+     */
+    public record ClusterSchemaResult(String status, String runningAt, String completedAt, List<List<ClusterSchemas>> schemas, Error error) {}
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaRestClient.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaRestClient.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+import com.ibm.watsonx.ai.WatsonxRestClient;
+
+
+/**
+ * Abstraction of a REST client for interacting with the IBM watsonx.ai Cluster Schema APIs.
+ */
+public abstract class ClusterSchemaRestClient extends WatsonxRestClient {
+
+    protected ClusterSchemaRestClient(Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Deletes a submitted cluster schema request job.
+     *
+     * @param request the {@link DeleteRequest} containing request id and parameters
+     * @return {@code true} if the job was successfully deleted, {@code false} otherwise
+     */
+    public abstract boolean deleteRequest(DeleteRequest request);
+
+    /**
+     * Retrieves the details and results of a submitted cluster schema request job.
+     *
+     * @param request the {@link FetchDetailsRequest} containing request id and fetch parameters
+     * @return a {@link ClusterSchemaResponse} containing the job status and results
+     */
+    public abstract ClusterSchemaResponse fetchRequestDetails(FetchDetailsRequest request);
+
+    /**
+     * Starts a new cluster schema request job.
+     *
+     * @param request the {@link StartClusterSchemaRequest} containing the schemas and parameters
+     * @return a {@link ClusterSchemaResponse} representing the created cluster schema job
+     */
+    public abstract ClusterSchemaResponse startRequest(StartClusterSchemaRequest request);
+
+    /**
+     * Creates a new {@link Builder} using the first available {@link ClusterSchemaRestClientBuilderFactory} discovered via {@link ServiceLoader}.
+     * <p>
+     * If no factory is found, falls back to the default {@link DefaultRestClient}.
+     */
+    static ClusterSchemaRestClient.Builder builder() {
+        return ServiceLoader.load(ClusterSchemaRestClientBuilderFactory.class).findFirst()
+            .map(Supplier::get)
+            .orElse(DefaultRestClient.builder());
+    }
+
+    /**
+     * Builder abstract class for constructing {@link ClusterSchemaRestClient} instances with configurable parameters.
+     */
+    public abstract static class Builder extends WatsonxRestClient.Builder<ClusterSchemaRestClient, Builder> {}
+
+    /**
+     * Service Provider Interface for supplying custom {@link Builder} implementations.
+     * <p>
+     * This allows frameworks to provide their own client implementations.
+     */
+    public interface ClusterSchemaRestClientBuilderFactory extends Supplier<ClusterSchemaRestClient.Builder> {}
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaSemanticConfig.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaSemanticConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import com.ibm.watsonx.ai.textprocessing.SemanticConfig;
+
+/**
+ * Represents the semantic configuration for cluster schema.
+ * <p>
+ * Instances of this class are created using the {@link Builder} pattern:
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ClusterSchemaSemanticConfig.builder()
+ *     .defaultModelName("my-custom-model")
+ *     .build();
+ * }</pre>
+ */
+public final class ClusterSchemaSemanticConfig extends SemanticConfig {
+
+    private ClusterSchemaSemanticConfig(Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ClusterSchemaSemanticConfig.builder()
+     *     .defaultModelName("my-custom-model")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link ClusterSchemaSemanticConfig} instance.
+     */
+    public static final class Builder extends SemanticConfig.Builder<Builder> {
+
+        private Builder() {}
+
+        /**
+         * Builds a {@link ClusterSchemaSemanticConfig} instance.
+         *
+         * @return a new instance of {@link ClusterSchemaSemanticConfig}
+         */
+        public ClusterSchemaSemanticConfig build() {
+            return new ClusterSchemaSemanticConfig(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterSchemaSemanticConfig [" + super.toString() + "]";
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemaService.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+import static java.util.Optional.ofNullable;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.ibm.watsonx.ai.WatsonxService.ProjectService;
+import com.ibm.watsonx.ai.core.auth.Authenticator;
+import com.ibm.watsonx.ai.textprocessing.Status;
+
+/**
+ * Service class to interact with IBM watsonx.ai Cluster Schema APIs.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ClusterSchemaService clusterSchemaService = ClusterSchemaService.builder()
+ *     .baseUrl("https://...")    // or use CloudRegion
+ *     .apiKey("my-api-key")      // creates an IBM Cloud Authenticator
+ *     .projectId("project-id")
+ *     .build();
+ *
+ * var clustered = clusterSchemaService.clusterSchemaAndFetch(schema1, schema2);
+ * }</pre>
+ *
+ * To use a custom authentication mechanism, configure it explicitly with {@code authenticator(Authenticator)}.
+ *
+ * @see Authenticator
+ */
+public class ClusterSchemaService extends ProjectService {
+    private static final Logger logger = LoggerFactory.getLogger(ClusterSchemaService.class);
+    private final ClusterSchemaRestClient client;
+
+    ClusterSchemaService() {
+        super();
+        client = null;
+    }
+
+    private ClusterSchemaService(Builder builder) {
+        super(builder);
+        requireNonNull(builder.authenticator(), "authenticator cannot be null");
+        client = ClusterSchemaRestClient.builder()
+            .baseUrl(baseUrl)
+            .version(version)
+            .logRequests(logRequests)
+            .logResponses(logResponses)
+            .timeout(timeout)
+            .authenticator(builder.authenticator())
+            .httpClient(httpClient)
+            .verifySsl(verifySsl)
+            .build();
+    }
+
+    /**
+     * Starts a cluster schema request for the given schemas.
+     *
+     * @param schemas the document schemas to cluster
+     * @return a {@link ClusterSchemaResponse} representing the submitted request and its current status
+     */
+    public ClusterSchemaResponse startClusterSchema(ClusterSchemas... schemas) throws ClusterSchemaException {
+        return startClusterSchema(null, List.of(schemas));
+    }
+
+    /**
+     * Starts a cluster schema request for the given schemas with optional parameters.
+     *
+     * @param parameters the configuration parameters for cluster schema
+     * @param schemas the document schemas to cluster
+     * @return a {@link ClusterSchemaResponse} representing the submitted request and its current status
+     */
+    public ClusterSchemaResponse startClusterSchema(ClusterSchemaParameters parameters, ClusterSchemas... schemas) throws ClusterSchemaException {
+        return startClusterSchema(parameters, List.of(schemas));
+    }
+
+    /**
+     * Starts a cluster schema request for the given list of schemas.
+     *
+     * @param schemas the document schemas to cluster
+     * @return a {@link ClusterSchemaResponse} representing the submitted request and its current status
+     */
+    public ClusterSchemaResponse startClusterSchema(List<ClusterSchemas> schemas) throws ClusterSchemaException {
+        return startClusterSchema(null, schemas);
+    }
+
+    /**
+     * Starts a cluster schema request for the given list of schemas with optional parameters.
+     *
+     * @param parameters the configuration parameters for cluster schema
+     * @param schemas the document schemas to cluster
+     * @return a {@link ClusterSchemaResponse} representing the submitted request and its current status
+     */
+    public ClusterSchemaResponse startClusterSchema(ClusterSchemaParameters parameters, List<ClusterSchemas> schemas) throws ClusterSchemaException {
+        return startClusterSchema(UUID.randomUUID().toString(), parameters, schemas, false);
+    }
+
+    /**
+     * Starts a cluster schema request and waits until the clustering is complete.
+     *
+     * @param schemas the document schemas to cluster
+     * @return a list of clusters, where each cluster contains the semantically similar {@link ClusterSchemas}
+     */
+    public List<List<ClusterSchemas>> clusterSchemaAndFetch(ClusterSchemas... schemas) throws ClusterSchemaException {
+        return clusterSchemaAndFetch(null, List.of(schemas));
+    }
+
+    /**
+     * Starts a cluster schema request and waits until the clustering is complete.
+     *
+     * @param parameters the configuration parameters for cluster schema
+     * @param schemas the document schemas to cluster
+     * @return a list of clusters, where each cluster contains the semantically similar {@link ClusterSchemas}
+     */
+    public List<List<ClusterSchemas>> clusterSchemaAndFetch(ClusterSchemaParameters parameters, ClusterSchemas... schemas)
+        throws ClusterSchemaException {
+        return clusterSchemaAndFetch(parameters, List.of(schemas));
+    }
+
+    /**
+     * Starts a cluster schema request and waits until the clustering is complete.
+     *
+     * @param schemas the document schemas to cluster
+     * @return a list of clusters, where each cluster contains the semantically similar {@link ClusterSchemas}
+     */
+    public List<List<ClusterSchemas>> clusterSchemaAndFetch(List<ClusterSchemas> schemas) throws ClusterSchemaException {
+        return clusterSchemaAndFetch(null, schemas);
+    }
+
+    /**
+     * Starts a cluster schema request and waits until the clustering is complete.
+     *
+     * @param parameters the configuration parameters for cluster schema
+     * @param schemas the document schemas to cluster
+     * @return a list of clusters, where each cluster contains the semantically similar {@link ClusterSchemas}
+     */
+    public List<List<ClusterSchemas>> clusterSchemaAndFetch(ClusterSchemaParameters parameters, List<ClusterSchemas> schemas)
+        throws ClusterSchemaException {
+        var requestId = UUID.randomUUID().toString();
+        var response = startClusterSchema(requestId, parameters, schemas, true);
+        return response.entity().results().schemas();
+    }
+
+    /**
+     * Retrieves the results of a cluster schema request by its unique identifier.
+     * <p>
+     * Note that the retention period for results is 2 days. If the request is older than 2 days, the results will no longer be available.
+     *
+     * @param id the unique identifier of the cluster schema request
+     * @return a {@link ClusterSchemaResponse} containing the results of the request
+     */
+    public ClusterSchemaResponse fetchRequest(String id) {
+        return fetchRequest(id, ClusterSchemaFetchParameters.builder().build());
+    }
+
+    /**
+     * Retrieves the results of a cluster schema request by its unique identifier.
+     * <p>
+     * Note that the retention period for results is 2 days. If the request is older than 2 days, the results will no longer be available.
+     *
+     * @param id the unique identifier of the cluster schema request
+     * @param parameters parameters to specify the project or space context in which the request was made
+     * @return a {@link ClusterSchemaResponse} containing the results of the request
+     */
+    public ClusterSchemaResponse fetchRequest(String id, ClusterSchemaFetchParameters parameters) {
+        requireNonNull(parameters, "parameters cannot be null");
+        return fetchClusterSchemaRequest(UUID.randomUUID().toString(), id, parameters);
+    }
+
+    /**
+     * Deletes a cluster schema request.
+     *
+     * @param id the unique identifier of the cluster schema request to delete
+     * @return {@code true} if the request was successfully deleted, {@code false} otherwise
+     */
+    public boolean deleteRequest(String id) {
+        return deleteRequest(id, ClusterSchemaDeleteParameters.builder().build());
+    }
+
+    /**
+     * Deletes a cluster schema request.
+     * <p>
+     * If the {@code hardDelete} parameter is set to {@code true}, it will also delete the associated job metadata.
+     *
+     * @param id the unique identifier of the cluster schema request to delete
+     * @param parameters parameters specifying the space or project context, and whether to perform a hard delete
+     * @return {@code true} if the request was successfully deleted, {@code false} otherwise
+     */
+    public boolean deleteRequest(String id, ClusterSchemaDeleteParameters parameters) {
+        requireNonNull(id, "The id cannot be null");
+        requireNonNull(parameters, "parameters cannot be null");
+
+        var builder = ClusterSchemaDeleteParameters.builder();
+        ofNullable(parameters.projectId()).ifPresent(builder::projectId);
+        ofNullable(parameters.spaceId()).ifPresent(builder::spaceId);
+
+        if (isNull(parameters.projectId()) && isNull(parameters.spaceId()))
+            builder.projectId(projectId).spaceId(spaceId);
+
+        var p = builder
+            .transactionId(parameters.transactionId())
+            .hardDelete(parameters.hardDelete().orElse(null))
+            .build();
+
+        var request = new DeleteRequest(parameters.transactionId(), id, p);
+        return client.deleteRequest(request);
+    }
+
+    //
+    // Retrieves the results of a cluster schema request by its unique identifier.
+    //
+    private ClusterSchemaResponse fetchClusterSchemaRequest(String requestId, String id, ClusterSchemaFetchParameters parameters) {
+        requireNonNull(requestId, "The requestId cannot be null");
+        requireNonNull(id, "The id cannot be null");
+
+        var builder = ClusterSchemaFetchParameters.builder();
+        ofNullable(parameters.projectId()).ifPresent(builder::projectId);
+        ofNullable(parameters.spaceId()).ifPresent(builder::spaceId);
+
+        if (isNull(parameters.projectId()) && isNull(parameters.spaceId()))
+            builder.projectId(projectId).spaceId(spaceId);
+
+        var p = builder
+            .transactionId(parameters.transactionId())
+            .build();
+
+        var request = new FetchDetailsRequest(requestId, id, p);
+        return client.fetchRequestDetails(request);
+    }
+
+    //
+    // Starts the cluster schema process and optionally waits for completion.
+    //
+    private ClusterSchemaResponse startClusterSchema(String requestId, ClusterSchemaParameters parameters, List<ClusterSchemas> schemas,
+        boolean waitUntilJobIsDone) throws ClusterSchemaException {
+        requireNonNull(requestId, "requestId cannot be null");
+        requireNonNull(schemas, "schemas cannot be null");
+
+        String projectId = null;
+        String spaceId = null;
+        Parameters params;
+        String transactionId = null;
+
+        if (nonNull(parameters)) {
+            projectId = parameters.projectId();
+            spaceId = parameters.spaceId();
+            var effectiveSchemas = requireNonNullElse(parameters.schemas(), schemas);
+            Parameters.SemanticConfig semanticConfigRecord = null;
+            if (parameters.semanticConfig() != null)
+                semanticConfigRecord = new Parameters.SemanticConfig(parameters.semanticConfig().defaultModelName());
+            params = new Parameters(effectiveSchemas, semanticConfigRecord);
+            transactionId = parameters.transactionId();
+        } else {
+            params = new Parameters(schemas, null);
+        }
+
+        if (isNull(projectId) && isNull(spaceId)) {
+            projectId = this.projectId;
+            spaceId = this.spaceId;
+        }
+
+        var clusterSchemaRequest = new ClusterSchemaRequest(projectId, spaceId, params);
+        var request = new StartClusterSchemaRequest(requestId, transactionId, clusterSchemaRequest);
+        var response = client.startRequest(request);
+
+        if (!waitUntilJobIsDone)
+            return response;
+
+        Status status = Status.fromValue(response.entity().results().status());
+        if (status == Status.COMPLETED)
+            return response;
+
+        if (status == Status.FAILED) {
+            var error = response.entity().results().error();
+            if (isNull(error))
+                throw new ClusterSchemaException("generic_error", "The cluster schema failed without error details");
+            throw new ClusterSchemaException(error.code(), error.message());
+        }
+
+        long sleepTime = 100;
+        long deadlineNanos = System.nanoTime() + this.timeout.toNanos();
+        String processId = response.metadata().id();
+
+        do {
+
+            if (System.nanoTime() - deadlineNanos >= 0) {
+                deleteRequest(
+                    processId,
+                    ClusterSchemaDeleteParameters.builder()
+                        .projectId(projectId)
+                        .spaceId(spaceId)
+                        .transactionId(transactionId)
+                        .build());
+                throw new ClusterSchemaException("timeout",
+                    "Execution of cluster schema took longer than the timeout set by %s milliseconds".formatted(this.timeout.toMillis()));
+            }
+
+            try {
+
+                Thread.sleep(sleepTime);
+                sleepTime *= 2;
+                sleepTime = Math.min(sleepTime, 3000);
+
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ClusterSchemaException("interrupted", e.getMessage());
+            }
+
+            processId = response.metadata().id();
+            response = fetchClusterSchemaRequest(requestId, processId, ClusterSchemaFetchParameters.builder()
+                .projectId(projectId)
+                .spaceId(spaceId)
+                .build());
+
+            status = Status.fromValue(response.entity().results().status());
+            logger.debug("Cluster schema status: {}", status);
+
+        } while (status != Status.FAILED && status != Status.COMPLETED);
+
+        if (status == Status.FAILED) {
+            var error = response.entity().results().error();
+            if (isNull(error))
+                throw new ClusterSchemaException("generic_error", "The cluster schema failed without error details");
+            throw new ClusterSchemaException(error.code(), error.message());
+        }
+
+        return response;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ClusterSchemaService clusterSchemaService = ClusterSchemaService.builder()
+     *     .baseUrl("https://...")
+     *     .apiKey("my-api-key")
+     *     .projectId("project-id")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link ClusterSchemaService} instances with configurable parameters.
+     */
+    public static final class Builder extends ProjectService.Builder<Builder> {
+
+        private Builder() {}
+
+        /**
+         * Builds a {@link ClusterSchemaService} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ClusterSchemaService}
+         */
+        public ClusterSchemaService build() {
+            return new ClusterSchemaService(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemas.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/ClusterSchemas.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import com.ibm.watsonx.ai.textprocessing.Schema;
+
+/**
+ * Represents a single schema entry used as input for the Cluster Schema API.
+ *
+ * @param documentName the name that identifies this document schema
+ * @param schema the schema definition for the document
+ */
+public record ClusterSchemas(String documentName, Schema schema) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/DefaultRestClient.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/DefaultRestClient.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import static com.ibm.watsonx.ai.core.Json.fromJson;
+import static com.ibm.watsonx.ai.core.Json.toJson;
+import static com.ibm.watsonx.ai.core.http.BaseHttpClient.REQUEST_ID_HEADER;
+import static java.util.Objects.nonNull;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import com.ibm.watsonx.ai.core.exception.WatsonxException;
+import com.ibm.watsonx.ai.core.factory.HttpClientFactory;
+import com.ibm.watsonx.ai.core.http.SyncHttpClient;
+import com.ibm.watsonx.ai.core.http.interceptors.LoggerInterceptor.LogMode;
+
+/**
+ * Default implementation of the {@link ClusterSchemaRestClient} abstract class.
+ */
+final class DefaultRestClient extends ClusterSchemaRestClient {
+    private final SyncHttpClient syncHttpClient;
+
+    DefaultRestClient(Builder builder) {
+        super(builder);
+        syncHttpClient = HttpClientFactory.createSync(authenticator, httpClient, LogMode.of(logRequests, logResponses));
+    }
+
+    @Override
+    public boolean deleteRequest(DeleteRequest request) {
+        var id = request.requestId();
+        var parameters = request.parameters();
+
+        var projectId = parameters.projectId();
+        var spaceId = parameters.spaceId();
+
+        var queryParameters = parameters.hardDelete()
+            .map(hardDelete -> getQueryParameters(projectId, spaceId).concat("&hard_delete=" + hardDelete))
+            .orElse(getQueryParameters(projectId, spaceId));
+
+        var uri = URI.create(baseUrl + "/ml/v1/text/schemas/cluster/%s?%s".formatted(id, queryParameters));
+        var httpRequest = HttpRequest.newBuilder(uri).timeout(timeout).DELETE();
+
+        if (nonNull(request.requestTrackingId()))
+            httpRequest.header(REQUEST_ID_HEADER, request.requestTrackingId());
+
+        if (nonNull(parameters.transactionId()))
+            httpRequest.header(TRANSACTION_ID_HEADER, parameters.transactionId());
+
+        try {
+
+            syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
+            return true;
+
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (WatsonxException e) {
+            if (e.statusCode() == 404)
+                return false;
+            throw e;
+        }
+    }
+
+    @Override
+    public ClusterSchemaResponse fetchRequestDetails(FetchDetailsRequest request) {
+        var id = request.requestId();
+        var parameters = request.parameters();
+        var projectId = parameters.projectId();
+        var spaceId = parameters.spaceId();
+
+        var queryParameters = getQueryParameters(projectId, spaceId);
+        var uri = URI.create(baseUrl + "/ml/v1/text/schemas/cluster/%s?%s".formatted(id, queryParameters));
+
+        var httpRequest = HttpRequest.newBuilder(uri)
+            .header("Accept", "application/json")
+            .timeout(timeout)
+            .GET();
+
+        if (nonNull(request.requestTrackingId()))
+            httpRequest.header(REQUEST_ID_HEADER, request.requestTrackingId());
+
+        if (nonNull(parameters.transactionId()))
+            httpRequest.header(TRANSACTION_ID_HEADER, parameters.transactionId());
+
+        try {
+
+            var httpResponse = syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
+            return fromJson(httpResponse.body(), ClusterSchemaResponse.class);
+
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ClusterSchemaResponse startRequest(StartClusterSchemaRequest request) {
+        var httpRequest =
+            HttpRequest.newBuilder(URI.create(baseUrl + "/ml/v1/text/schemas/cluster?version=%s".formatted(version)))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(BodyPublishers.ofString(toJson(request.clusterSchemaRequest())))
+                .timeout(timeout);
+
+        if (nonNull(request.requestTrackingId()))
+            httpRequest.header(REQUEST_ID_HEADER, request.requestTrackingId());
+
+        if (nonNull(request.transactionId()))
+            httpRequest.header(TRANSACTION_ID_HEADER, request.transactionId());
+
+        try {
+
+            var httpResponse = syncHttpClient.send(httpRequest.build(), BodyHandlers.ofString());
+            return fromJson(httpResponse.body(), ClusterSchemaResponse.class);
+
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //
+    // Generates query parameters for API requests based on provided project_id or space_id.
+    //
+    private String getQueryParameters(String projectId, String spaceId) {
+        if (nonNull(projectId))
+            return "version=%s&project_id=%s".formatted(version, URLEncoder.encode(projectId, StandardCharsets.UTF_8));
+        else
+            return "version=%s&space_id=%s".formatted(version, URLEncoder.encode(spaceId, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link DefaultRestClient} instances with configurable parameters.
+     */
+    public static class Builder extends ClusterSchemaRestClient.Builder {
+
+        /**
+         * Builds a {@link DefaultRestClient} instance using the configured parameters.
+         *
+         * @return a new instance of {@link DefaultRestClient}
+         */
+        public DefaultRestClient build() {
+            return new DefaultRestClient(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/DeleteRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/DeleteRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+/**
+ * Represents a request to delete a submitted cluster schema job.
+ *
+ * @param requestTrackingId optional identifier used internally by the SDK to trace requests
+ * @param requestId the unique identifier of the cluster schema job to delete
+ * @param parameters additional parameters controlling the delete operation
+ */
+public record DeleteRequest(String requestTrackingId, String requestId, ClusterSchemaDeleteParameters parameters) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/FetchDetailsRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/FetchDetailsRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+/**
+ * Represents a request to fetch the details and results of a cluster schema job.
+ *
+ * @param requestTrackingId optional identifier used internally by the SDK to trace requests
+ * @param requestId the unique identifier of the cluster schema job to fetch
+ * @param parameters additional parameters specifying the fetch operation
+ */
+public record FetchDetailsRequest(String requestTrackingId, String requestId, ClusterSchemaFetchParameters parameters) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/Parameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/Parameters.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+import java.util.List;
+
+/**
+ * Represents the configuration parameters used by the Cluster Schema API.
+ *
+ * @param schemas a list of document schemas to cluster
+ * @param semanticConfig properties related to semantic config
+ */
+public record Parameters(List<ClusterSchemas> schemas, SemanticConfig semanticConfig) {
+
+    /**
+     * Represents the semantic configuration for the Cluster Schema API.
+     *
+     * @param defaultModelName the model name to use
+     */
+    public record SemanticConfig(String defaultModelName) {}
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/StartClusterSchemaRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/textprocessing/schema/cluster/StartClusterSchemaRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema.cluster;
+
+/**
+ * Represents a request to start a new cluster schema job.
+ *
+ * @param requestTrackingId optional identifier used internally by the SDK to trace requests
+ * @param transactionId optional transaction identifier for correlating multiple related operations
+ * @param clusterSchemaRequest the request body
+ */
+public record StartClusterSchemaRequest(String requestTrackingId, String transactionId, ClusterSchemaRequest clusterSchemaRequest) {}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ClusterSchemaIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ClusterSchemaIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import com.ibm.watsonx.ai.core.exception.WatsonxException;
+import com.ibm.watsonx.ai.textprocessing.KvpFields;
+import com.ibm.watsonx.ai.textprocessing.KvpFields.KvpField;
+import com.ibm.watsonx.ai.textprocessing.Schema;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaDeleteParameters;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaException;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaParameters;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaSemanticConfig;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaService;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemas;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class ClusterSchemaIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
+    static final String URL = System.getenv("WATSONX_URL");
+
+    static final ClusterSchemaService clusterSchemaService = ClusterSchemaService.builder()
+        .baseUrl(URL)
+        .apiKey(API_KEY)
+        .projectId(PROJECT_ID)
+        .logRequests(true)
+        .logResponses(true)
+        .build();
+
+    static final ClusterSchemas PASSPORT = new ClusterSchemas("Passport",
+        Schema.builder()
+            .documentType("Passport")
+            .documentDescription("A government-issued travel document containing personal information and travel visas")
+            .fields(KvpFields.builder()
+                .add("surname", KvpField.of("The holder's last name", "SMITH"))
+                .add("given_names", KvpField.of("The holder's first and middle names", "ALICE MARIE"))
+                .add("nationality", KvpField.of("The holder's nationality", "ITALIAN"))
+                .add("date_of_birth", KvpField.of("Date of birth in DD MMM YYYY format", "01 JAN 1990"))
+                .add("passport_number", KvpField.of("Unique passport identifier", "YA1234567"))
+                .build())
+            .build());
+
+    static final ClusterSchemas NATIONAL_ID = new ClusterSchemas("National_ID",
+        Schema.builder()
+            .documentType("National ID Card")
+            .documentDescription("A government-issued national identity document for citizens")
+            .fields(KvpFields.builder()
+                .add("surname", KvpField.of("The holder's family name", "DOE"))
+                .add("given_names", KvpField.of("The holder's first and middle names", "JOHN JAMES"))
+                .add("date_of_birth", KvpField.of("Date of birth", "15/03/1985"))
+                .add("id_number", KvpField.of("Unique national ID number", "AB123456C"))
+                .build())
+            .build());
+
+    static final ClusterSchemas INVOICE = new ClusterSchemas("Invoice",
+        Schema.builder()
+            .documentType("Invoice")
+            .documentDescription("A commercial document issued by a seller to a buyer for goods or services")
+            .fields(KvpFields.builder()
+                .add("invoice_number", KvpField.of("Unique invoice identifier", "INV-2024-001"))
+                .add("invoice_date", KvpField.of("Date the invoice was issued", "2024-01-15"))
+                .add("total_amount", KvpField.of("Total amount due including taxes", "1250.00 EUR"))
+                .add("vendor_name", KvpField.of("Name of the company issuing the invoice", "Acme Corp"))
+                .add("customer_name", KvpField.of("Name of the customer", "Big Client Ltd"))
+                .build())
+            .build());
+
+    @Test
+    void should_cluster_schemas_and_return_grouped_results() throws Exception {
+
+        var groups = clusterSchemaService.clusterSchemaAndFetch(PASSPORT, NATIONAL_ID, INVOICE);
+
+        assertNotNull(groups);
+        assertFalse(groups.isEmpty());
+
+        var allNames = groups.stream()
+            .flatMap(cluster -> cluster.stream().map(ClusterSchemas::documentName))
+            .toList();
+        assertTrue(allNames.contains("Passport"), "Expected Passport in: " + allNames);
+        assertTrue(allNames.contains("National_ID"), "Expected National_ID in: " + allNames);
+        assertTrue(allNames.contains("Invoice"), "Expected Invoice in: " + allNames);
+        assertEquals(3, allNames.size(), "Each schema name should appear exactly once, got: " + allNames);
+    }
+
+    @Test
+    void should_start_cluster_schema_and_fetch_by_id() throws Exception {
+
+        var response = clusterSchemaService.startClusterSchema(PASSPORT, NATIONAL_ID);
+        assertNotNull(response);
+        assertNotNull(response.metadata().id());
+        assertNotNull(response.entity().results().status());
+
+        // Poll until complete using fetchRequest
+        String id = response.metadata().id();
+        ClusterSchemaIT.waitUntilComplete(id);
+
+        var completed = clusterSchemaService.fetchRequest(id);
+        assertNotNull(completed.entity().results().schemas());
+
+        assertTrue(clusterSchemaService.deleteRequest(id, ClusterSchemaDeleteParameters.builder().hardDelete(true).build()));
+    }
+
+    @Test
+    void should_delete_cluster_schema_request() throws Exception {
+
+        var response = clusterSchemaService.startClusterSchema(PASSPORT);
+        assertNotNull(response.metadata().id());
+
+        assertTrue(clusterSchemaService.deleteRequest(
+            response.metadata().id(),
+            ClusterSchemaDeleteParameters.builder().hardDelete(true).build()));
+
+        var ex = assertThrows(WatsonxException.class,
+            () -> clusterSchemaService.fetchRequest(response.metadata().id()));
+        assertTrue(ex.statusCode() == 404);
+    }
+
+    @Test
+    void should_return_false_when_deleting_non_existing_request() {
+        assertFalse(clusterSchemaService.deleteRequest("non-existing-id"));
+    }
+
+    @Test
+    void should_throw_when_fetching_non_existing_request() {
+        var ex = assertThrows(WatsonxException.class,
+            () -> clusterSchemaService.fetchRequest("non-existing-id"));
+        assertTrue(ex.statusCode() == 404);
+    }
+
+    @Test
+    void should_cluster_schemas_with_semantic_config() throws Exception {
+
+        var groups = clusterSchemaService.clusterSchemaAndFetch(
+            ClusterSchemaParameters.builder()
+                .semanticConfig(ClusterSchemaSemanticConfig.builder()
+                    .build())
+                .build(),
+            PASSPORT, NATIONAL_ID);
+
+        assertNotNull(groups);
+        assertFalse(groups.isEmpty());
+    }
+
+    private static void waitUntilComplete(String id) throws Exception {
+        long deadline = System.currentTimeMillis() + 120_000;
+        while (System.currentTimeMillis() < deadline) {
+            var r = clusterSchemaService.fetchRequest(id);
+            var status = r.entity().results().status();
+            if ("completed".equals(status) || "failed".equals(status))
+                return;
+            Thread.sleep(2000);
+        }
+        throw new ClusterSchemaException("timeout", "Timed out waiting for cluster schema job " + id);
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/textprocessing/schema/ClusterSchemaTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/textprocessing/schema/ClusterSchemaTest.java
@@ -1,0 +1,651 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.textprocessing.schema;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.ibm.watsonx.ai.core.Json.toJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.skyscreamer.jsonassert.JSONAssert;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.ibm.watsonx.ai.AbstractWatsonxTest;
+import com.ibm.watsonx.ai.core.Json;
+import com.ibm.watsonx.ai.textprocessing.Schema;
+import com.ibm.watsonx.ai.textprocessing.Status;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaDeleteParameters;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaException;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaFetchParameters;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaParameters;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaResponse;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaSemanticConfig;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaService;
+import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemas;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ClusterSchemaTest extends AbstractWatsonxTest {
+
+    @RegisterExtension
+    WireMockExtension watsonxServer = WireMockExtension.newInstance()
+        .options(com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig().dynamicPort())
+        .build();
+
+    ClusterSchemaService clusterSchemaService;
+
+    static final ClusterSchemas PASSPORT = new ClusterSchemas("Passport",
+        Schema.builder().documentType("Passport").documentDescription("A government-issued travel document").build());
+
+    static final ClusterSchemas NATIONAL_ID = new ClusterSchemas("National_ID",
+        Schema.builder().documentType("National ID").documentDescription("A government-issued national identity card").build());
+
+    @BeforeEach
+    void beforeEach() {
+        watsonxServer.resetAll();
+        when(mockAuthenticator.token()).thenReturn("token");
+        clusterSchemaService = ClusterSchemaService.builder()
+            .baseUrl("http://localhost:%s".formatted(watsonxServer.getPort()))
+            .authenticator(mockAuthenticator)
+            .projectId("project-id")
+            .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // startClusterSchema
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_start_cluster_schema_with_varargs() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withHeader("Accept", equalTo("application/json"))
+            .withRequestBody(equalToJson("""
+                {
+                    "project_id": "project-id",
+                    "parameters": {
+                        "schemas": [
+                            {
+                                "document_name": "Passport",
+                                "schema": {
+                                    "document_type": "Passport",
+                                    "document_description": "A government-issued travel document"
+                                }
+                            },
+                            {
+                                "document_name": "National_ID",
+                                "schema": {
+                                    "document_type": "National ID",
+                                    "document_description": "A government-issued national identity card"
+                                }
+                            }
+                        ]
+                    }
+                }"""))
+            .willReturn(aResponse()
+                .withStatus(201)
+                .withBody(RESPONSE.formatted("submitted"))
+            ));
+
+        var result = clusterSchemaService.startClusterSchema(PASSPORT, NATIONAL_ID);
+        assertNotNull(result);
+        assertEquals("id", result.metadata().id());
+        assertEquals("submitted", result.entity().results().status());
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+    }
+
+    @Test
+    void should_start_cluster_schema_with_parameters_and_semantic_config() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withHeader("Accept", equalTo("application/json"))
+            .withHeader(TRANSACTION_ID_HEADER, equalTo("tx-id"))
+            .withRequestBody(equalToJson("""
+                {
+                    "project_id": "custom-project",
+                    "parameters": {
+                        "schemas": [
+                            {
+                                "document_name": "Passport",
+                                "schema": {
+                                    "document_type": "Passport",
+                                    "document_description": "A government-issued travel document"
+                                }
+                            }
+                        ],
+                        "semantic_config": {
+                            "default_model_name": "my-model"
+                        }
+                    }
+                }"""))
+            .willReturn(aResponse()
+                .withStatus(201)
+                .withBody(RESPONSE.formatted("submitted"))
+            ));
+
+        var parameters = ClusterSchemaParameters.builder()
+            .projectId("custom-project")
+            .transactionId("tx-id")
+            .semanticConfig(ClusterSchemaSemanticConfig.builder().defaultModelName("my-model").build())
+            .build();
+
+        var result = clusterSchemaService.startClusterSchema(parameters, PASSPORT);
+        assertNotNull(result);
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+    }
+
+    @Test
+    void should_start_cluster_schema_with_space_id() throws Exception {
+
+        var service = ClusterSchemaService.builder()
+            .baseUrl("http://localhost:%s".formatted(watsonxServer.getPort()))
+            .authenticator(mockAuthenticator)
+            .spaceId("space-id")
+            .build();
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .withRequestBody(equalToJson("""
+                {
+                    "space_id": "space-id",
+                    "parameters": {
+                        "schemas": [
+                            {
+                                "document_name": "Passport",
+                                "schema": {
+                                    "document_type": "Passport",
+                                    "document_description": "A government-issued travel document"
+                                }
+                            }
+                        ]
+                    }
+                }"""))
+            .willReturn(aResponse()
+                .withStatus(201)
+                .withBody(RESPONSE.formatted("submitted"))
+            ));
+
+        var result = service.startClusterSchema(PASSPORT);
+        assertNotNull(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // clusterSchemaAndFetch (polling)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_cluster_schema_and_fetch_completed_immediately() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_response.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody(RESPONSE)));
+
+        var groups = clusterSchemaService.clusterSchemaAndFetch(PASSPORT, NATIONAL_ID);
+        assertNotNull(groups);
+        assertEquals(1, groups.size());
+        var names = groups.get(0).stream().map(ClusterSchemas::documentName).toList();
+        assertTrue(names.contains("Passport"));
+        assertTrue(names.contains("National_ID"));
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster/id")));
+    }
+
+    @Test
+    void should_cluster_schema_with_polling_retries() throws Exception {
+
+        var JOB = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_response.json").toURI()));
+        var projectId = URLEncoder.encode("project-id", Charset.defaultCharset());
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .inScenario("polling")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willSetStateTo("first")
+            .willReturn(aResponse().withStatus(201).withBody(JOB.formatted("submitted"))));
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .inScenario("polling")
+            .whenScenarioStateIs("first")
+            .willSetStateTo("second")
+            .willReturn(aResponse().withStatus(200).withBody(JOB.formatted("running"))));
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .inScenario("polling")
+            .whenScenarioStateIs("second")
+            .willSetStateTo(Scenario.STARTED)
+            .willReturn(aResponse().withStatus(200).withBody(RESPONSE)));
+
+        var groups = clusterSchemaService.clusterSchemaAndFetch(PASSPORT, NATIONAL_ID);
+        assertNotNull(groups);
+        assertFalse(groups.isEmpty());
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+        watsonxServer.verify(2, getRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster/id")));
+    }
+
+    @Test
+    void should_throw_exception_when_cluster_schema_job_fails() throws Exception {
+
+        var JOB = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+        var JOB_ERROR = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job_error.json").toURI()));
+        var projectId = URLEncoder.encode("project-id", Charset.defaultCharset());
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .inScenario("fail")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willSetStateTo("running")
+            .willReturn(aResponse().withStatus(201).withBody(JOB.formatted("submitted"))));
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .inScenario("fail")
+            .whenScenarioStateIs("running")
+            .willSetStateTo(Scenario.STARTED)
+            .willReturn(aResponse().withStatus(200).withBody(JOB_ERROR)));
+
+        var ex = assertThrows(ClusterSchemaException.class,
+            () -> clusterSchemaService.clusterSchemaAndFetch(PASSPORT, NATIONAL_ID));
+        assertEquals("cluster_error", ex.code());
+        assertEquals("cluster error message", ex.getMessage());
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+        watsonxServer.verify(1, getRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster/id")));
+    }
+
+    @Test
+    void should_throw_cluster_schema_exception_with_no_error_details_when_job_fails_without_error() throws Exception {
+
+        var projectId = URLEncoder.encode("project-id", Charset.defaultCharset());
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody("""
+                {
+                    "metadata": {"id": "id", "created_at": "2025-01-01T00:00:00Z", "project_id": "project-id"},
+                    "entity": {"parameters": {"schemas": []}, "results": {"status": "submitted"}}
+                }""")));
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .willReturn(aResponse().withStatus(200).withBody("""
+                {
+                    "metadata": {"id": "id", "created_at": "2025-01-01T00:00:00Z", "project_id": "project-id"},
+                    "entity": {"parameters": {"schemas": []}, "results": {"status": "failed"}}
+                }""")));
+
+        var ex = assertThrows(ClusterSchemaException.class,
+            () -> clusterSchemaService.clusterSchemaAndFetch(PASSPORT));
+        assertEquals("generic_error", ex.code());
+        assertEquals("The cluster schema failed without error details", ex.getMessage());
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchRequest
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_fetch_cluster_schema_request() throws Exception {
+
+        var JOB = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+        var projectId = URLEncoder.encode("project-id", Charset.defaultCharset());
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse().withStatus(200).withBody(JOB.formatted(Status.SUBMITTED.value()))));
+
+        var response = clusterSchemaService.fetchRequest("id");
+        JSONAssert.assertEquals(JOB.formatted(Status.SUBMITTED.value()), Json.toJson(response), true);
+
+        // With explicit project override + transaction id
+        var newProjectId = URLEncoder.encode("new-project-id", Charset.defaultCharset());
+        watsonxServer.resetAll();
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, newProjectId))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .withHeader(TRANSACTION_ID_HEADER, equalTo("tx-123"))
+            .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        var p = ClusterSchemaFetchParameters.builder().projectId("new-project-id").transactionId("tx-123").build();
+        response = clusterSchemaService.fetchRequest("id", p);
+        assertNotNull(response);
+
+        // With space id override
+        var spaceId = URLEncoder.encode("new-space-id", Charset.defaultCharset());
+        watsonxServer.resetAll();
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&space_id=%s".formatted(API_VERSION, spaceId))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        p = ClusterSchemaFetchParameters.builder().spaceId("new-space-id").build();
+        response = clusterSchemaService.fetchRequest("id", p);
+        assertNotNull(response);
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteRequest
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_delete_cluster_schema_request() {
+
+        var projectId = URLEncoder.encode("project-id", Charset.defaultCharset());
+
+        // Default delete - returns 204 success
+        watsonxServer.stubFor(delete("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .willReturn(aResponse().withStatus(204)));
+
+        assertTrue(clusterSchemaService.deleteRequest("id"));
+
+        // 404 returns false
+        watsonxServer.stubFor(delete("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .withHeader("Authorization", equalTo("Bearer token"))
+            .willReturn(aResponse().withStatus(404).withBody("""
+                {
+                    "trace": "abc123",
+                    "errors": [{"code": "not_found", "message": "Request not found."}]
+                }""")));
+
+        assertFalse(clusterSchemaService.deleteRequest("id"));
+
+        // With hard_delete=true + custom project + transaction id
+        var newProjectId = URLEncoder.encode("new-project-id", Charset.defaultCharset());
+        watsonxServer.stubFor(
+            delete("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s&hard_delete=true".formatted(API_VERSION, newProjectId))
+                .withHeader("Authorization", equalTo("Bearer token"))
+                .withHeader(TRANSACTION_ID_HEADER, equalTo("tx-id"))
+                .willReturn(aResponse().withStatus(204)));
+
+        var p = ClusterSchemaDeleteParameters.builder()
+            .projectId("new-project-id")
+            .hardDelete(true)
+            .transactionId("tx-id")
+            .build();
+        assertTrue(clusterSchemaService.deleteRequest("id", p));
+
+        // With space id
+        var spaceId = URLEncoder.encode("new-space-id", Charset.defaultCharset());
+        watsonxServer.stubFor(
+            delete("/ml/v1/text/schemas/cluster/id?version=%s&space_id=%s".formatted(API_VERSION, spaceId))
+                .withHeader("Authorization", equalTo("Bearer token"))
+                .willReturn(aResponse().withStatus(204)));
+
+        p = ClusterSchemaDeleteParameters.builder().spaceId("new-space-id").build();
+        assertTrue(clusterSchemaService.deleteRequest("id", p));
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON serialisation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_serialise_cluster_schema_response() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_response.json").toURI()));
+
+        var response = Json.fromJson(RESPONSE, ClusterSchemaResponse.class);
+        assertNotNull(response);
+        assertEquals("id", response.metadata().id());
+        assertEquals("completed", response.entity().results().status());
+        assertEquals("2025-10-23T13:12:20.000Z", response.entity().results().runningAt());
+        assertEquals("2025-10-23T13:12:25.000Z", response.entity().results().completedAt());
+        assertNotNull(response.entity().results().schemas());
+        assertEquals(1, response.entity().results().schemas().size());
+        var cluster = response.entity().results().schemas().get(0);
+        assertEquals(2, cluster.size());
+        assertEquals("Passport", cluster.get(0).documentName());
+        assertEquals("National_ID", cluster.get(1).documentName());
+
+        JSONAssert.assertEquals(RESPONSE, toJson(response), true);
+    }
+
+    @Test
+    void should_build_cluster_schema_parameters() {
+
+        var p = ClusterSchemaParameters.builder()
+            .projectId("proj")
+            .transactionId("tx")
+            .schemas(PASSPORT, NATIONAL_ID)
+            .semanticConfig(ClusterSchemaSemanticConfig.builder().defaultModelName("model").build())
+            .build();
+
+        assertEquals("proj", p.projectId());
+        assertEquals("tx", p.transactionId());
+        assertEquals(2, p.schemas().size());
+        assertEquals("model", p.semanticConfig().defaultModelName());
+
+        var params = p.toParameters();
+        assertEquals(2, params.schemas().size());
+        assertEquals("model", params.semanticConfig().defaultModelName());
+    }
+
+    @Test
+    void should_build_cluster_schema_delete_parameters_with_hard_delete() {
+
+        var p = ClusterSchemaDeleteParameters.builder()
+            .projectId("proj")
+            .hardDelete(true)
+            .build();
+
+        assertEquals("proj", p.projectId());
+        assertTrue(p.hardDelete().orElseThrow());
+        assertTrue(p.toString().contains("hardDelete=Optional[true]"));
+    }
+
+    @Test
+    void should_have_empty_hard_delete_when_not_set() {
+
+        var p = ClusterSchemaDeleteParameters.builder().projectId("proj").build();
+        assertTrue(p.hardDelete().isEmpty());
+    }
+
+    @Test
+    void should_build_cluster_schema_exception_correctly() {
+
+        var ex = new ClusterSchemaException("code", "message");
+        assertEquals("code", ex.code());
+        assertEquals("message", ex.getMessage());
+        assertEquals("ClusterSchemaException [code=code, message=message]", ex.toString());
+
+        var cause = new RuntimeException("cause");
+        var ex2 = new ClusterSchemaException("code2", "message2", cause);
+        assertEquals("code2", ex2.code());
+        assertEquals(cause, ex2.getCause());
+    }
+
+    // -------------------------------------------------------------------------
+    // List overloads
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_start_cluster_schema_with_list() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody(RESPONSE.formatted("submitted"))));
+
+        var result = clusterSchemaService.startClusterSchema(List.of(PASSPORT, NATIONAL_ID));
+        assertNotNull(result);
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+    }
+
+    @Test
+    void should_cluster_schema_and_fetch_with_list() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_response.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody(RESPONSE)));
+
+        var groups = clusterSchemaService.clusterSchemaAndFetch(List.of(PASSPORT, NATIONAL_ID));
+        assertNotNull(groups);
+        assertFalse(groups.isEmpty());
+    }
+
+    @Test
+    void should_cluster_schema_and_fetch_with_params_and_varargs() throws Exception {
+
+        var RESPONSE = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_response.json").toURI()));
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody(RESPONSE)));
+
+        var params = ClusterSchemaParameters.builder().build();
+        var groups = clusterSchemaService.clusterSchemaAndFetch(params, PASSPORT, NATIONAL_ID);
+        assertNotNull(groups);
+        assertFalse(groups.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Immediate FAILED from POST response (before any polling)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_throw_exception_when_post_response_is_immediately_failed() throws Exception {
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody("""
+                {
+                    "metadata": {"id": "id", "created_at": "2025-01-01T00:00:00Z", "project_id": "project-id"},
+                    "entity": {"parameters": {"schemas": []}, "results": {"status": "failed",
+                        "error": {"code": "immediate_error", "message": "failed right away"}}}
+                }""")));
+
+        var ex = assertThrows(ClusterSchemaException.class,
+            () -> clusterSchemaService.clusterSchemaAndFetch(PASSPORT));
+        assertEquals("immediate_error", ex.code());
+        assertEquals("failed right away", ex.getMessage());
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster/id")));
+    }
+
+    @Test
+    void should_throw_generic_error_when_post_response_is_failed_without_error() throws Exception {
+
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse().withStatus(201).withBody("""
+                {
+                    "metadata": {"id": "id", "created_at": "2025-01-01T00:00:00Z", "project_id": "project-id"},
+                    "entity": {"parameters": {"schemas": []}, "results": {"status": "failed"}}
+                }""")));
+
+        var ex = assertThrows(ClusterSchemaException.class,
+            () -> clusterSchemaService.clusterSchemaAndFetch(PASSPORT));
+        assertEquals("generic_error", ex.code());
+
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster/id")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Timeout during polling
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_throw_exception_on_timeout_and_delete_job() throws Exception {
+
+        var JOB = Files.readString(Path.of(ClassLoader.getSystemResource("cluster_schema_job.json").toURI()));
+        var projectId = URLEncoder.encode("project-id", Charset.defaultCharset());
+
+        // POST returns "submitted", GET always returns "running" → polling never completes
+        watsonxServer.stubFor(post("/ml/v1/text/schemas/cluster?version=%s".formatted(API_VERSION))
+            .inScenario("timeout")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willSetStateTo("polling")
+            .willReturn(aResponse().withStatus(201).withBody(JOB.formatted("submitted"))));
+
+        watsonxServer.stubFor(get("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .inScenario("timeout")
+            .whenScenarioStateIs("polling")
+            .willReturn(aResponse().withStatus(200).withBody(JOB.formatted("running"))));
+
+        watsonxServer.stubFor(delete("/ml/v1/text/schemas/cluster/id?version=%s&project_id=%s".formatted(API_VERSION, projectId))
+            .willReturn(aResponse().withStatus(204)));
+
+        // 100ms is enough for HTTP calls but short enough that polling times out after first GET
+        var shortTimeoutService = ClusterSchemaService.builder()
+            .baseUrl("http://localhost:%s".formatted(watsonxServer.getPort()))
+            .authenticator(mockAuthenticator)
+            .projectId("project-id")
+            .timeout(java.time.Duration.ofMillis(100))
+            .build();
+
+        var ex = assertThrows(ClusterSchemaException.class,
+            () -> shortTimeoutService.clusterSchemaAndFetch(PASSPORT));
+        assertEquals("timeout", ex.code());
+        assertTrue(ex.getMessage().contains("milliseconds"));
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster")));
+        watsonxServer.verify(1, deleteRequestedFor(urlPathEqualTo("/ml/v1/text/schemas/cluster/id")));
+    }
+
+    // -------------------------------------------------------------------------
+    // toString / builder coverage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_cover_to_string_methods() {
+
+        var p = ClusterSchemaParameters.builder()
+            .schemas(List.of(PASSPORT))
+            .semanticConfig(ClusterSchemaSemanticConfig.builder().defaultModelName("m").build())
+            .build();
+        assertTrue(p.toString().contains("ClusterSchemaParameters"));
+        assertTrue(p.toString().contains("schemas="));
+
+        assertTrue(ClusterSchemaSemanticConfig.builder().defaultModelName("x").build().toString()
+            .contains("ClusterSchemaSemanticConfig"));
+        assertTrue(ClusterSchemaFetchParameters.builder().projectId("p").build().toString()
+            .contains("ClusterSchemaFetchParameters"));
+    }
+
+    @Test
+    void should_build_parameters_with_list_schemas() {
+
+        var p = ClusterSchemaParameters.builder()
+            .schemas(List.of(PASSPORT, NATIONAL_ID))
+            .build();
+        assertEquals(2, p.schemas().size());
+        assertEquals("Passport", p.schemas().get(0).documentName());
+    }
+}

--- a/modules/watsonx-ai/src/test/resources/cluster_schema_job.json
+++ b/modules/watsonx-ai/src/test/resources/cluster_schema_job.json
@@ -1,0 +1,30 @@
+{
+    "metadata": {
+        "id": "id",
+        "created_at": "2025-10-23T13:12:19.499Z",
+        "project_id": "project-id"
+    },
+    "entity": {
+        "parameters": {
+            "schemas": [
+                {
+                    "document_name": "Passport",
+                    "schema": {
+                        "document_type": "Passport",
+                        "document_description": "A government-issued travel document"
+                    }
+                },
+                {
+                    "document_name": "National_ID",
+                    "schema": {
+                        "document_type": "National ID",
+                        "document_description": "A government-issued national identity card"
+                    }
+                }
+            ]
+        },
+        "results": {
+            "status": "%s"
+        }
+    }
+}

--- a/modules/watsonx-ai/src/test/resources/cluster_schema_job_error.json
+++ b/modules/watsonx-ai/src/test/resources/cluster_schema_job_error.json
@@ -1,0 +1,19 @@
+{
+    "metadata": {
+        "id": "id",
+        "created_at": "2025-10-23T13:12:19.499Z",
+        "project_id": "project-id"
+    },
+    "entity": {
+        "parameters": {
+            "schemas": []
+        },
+        "results": {
+            "status": "failed",
+            "error": {
+                "code": "cluster_error",
+                "message": "cluster error message"
+            }
+        }
+    }
+}

--- a/modules/watsonx-ai/src/test/resources/cluster_schema_response.json
+++ b/modules/watsonx-ai/src/test/resources/cluster_schema_response.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "id": "id",
+        "created_at": "2025-10-23T13:12:19.499Z",
+        "project_id": "project-id"
+    },
+    "entity": {
+        "parameters": {
+            "schemas": [
+                {
+                    "document_name": "Passport",
+                    "schema": {
+                        "document_type": "Passport",
+                        "document_description": "A government-issued travel document"
+                    }
+                },
+                {
+                    "document_name": "National_ID",
+                    "schema": {
+                        "document_type": "National ID",
+                        "document_description": "A government-issued national identity card"
+                    }
+                }
+            ]
+        },
+        "results": {
+            "status": "completed",
+            "running_at": "2025-10-23T13:12:20.000Z",
+            "completed_at": "2025-10-23T13:12:25.000Z",
+            "schemas": [
+                [
+                    {
+                        "document_name": "Passport",
+                        "schema": {
+                            "document_type": "Passport",
+                            "document_description": "A government-issued travel document"
+                        }
+                    },
+                    {
+                        "document_name": "National_ID",
+                        "schema": {
+                            "document_type": "National ID",
+                            "document_description": "A government-issued national identity card"
+                        }
+                    }
+                ]
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `ClusterSchemaService` that groups a set of document schemas into semantically similar cluster.