### PR TITLE
Add `ModelGatewayCatalogService` for listing and fetching gateway models

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,41 @@ See the [documentation](https://ibm.github.io/watsonx-ai-java-sdk/) for advanced
 
 The SDK provides a unified Java interface to the watsonx.ai ecosystem and works with both **IBM Cloud** and **CP4D** (on-premises) deployments.
 
+### Inference
+
 | Service | Description |
 |---------|-------------|
 | **[Chat](https://ibm.github.io/watsonx-ai-java-sdk/services/chat-service/)** | Conversational AI with multi-turn dialogue, streaming, tool calling, vision, and reasoning |
-| **[Model Gateway](https://ibm.github.io/watsonx-ai-java-sdk/services/model-gateway/)** | Chat with third-party models |
 | **[Embedding](https://ibm.github.io/watsonx-ai-java-sdk/services/embedding-service/)** | Dense vector representations for semantic search, similarity, and RAG |
 | **[Rerank](https://ibm.github.io/watsonx-ai-java-sdk/services/rerank-service/)** | Relevance scoring and reordering of candidate documents |
-| **[Detection](https://ibm.github.io/watsonx-ai-java-sdk/services/detection-service/)** | Identification of harmful content (HAP), PII, and safety violations |
-| **[Tokenization](https://ibm.github.io/watsonx-ai-java-sdk/services/tokenization-service/)** | Token counting and analysis for any model |
-| **[Foundation Model](https://ibm.github.io/watsonx-ai-java-sdk/services/foundation-model-service/)** | Browse and query the watsonx.ai model catalog |
-| **[Schema](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/schema/)** | Create, improve, merge, and cluster document schemas |
-| **[Text Classification](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/text-classification-service/)** | Document classification from IBM Cloud Object Storage |
-| **[Text Extraction](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/text-extraction-service/)** | Structured data extraction from documents in IBM Cloud Object Storage |
 | **[Time Series](https://ibm.github.io/watsonx-ai-java-sdk/services/time-series-service/)** | Time series forecasting using IBM Granite TTM models |
-| **[Tool](https://ibm.github.io/watsonx-ai-java-sdk/services/tool-service/)** | Server-side utility tools for agentic workflows |
 | **[Deployment](https://ibm.github.io/watsonx-ai-java-sdk/services/deployment-service/)** | Chat and forecasting via deployed model endpoints |
+
+### Model Gateway
+
+Proxy layer that routes requests to third-party foundation models (OpenAI, Anthropic, Azure, Mistral, and others) through a single IBM-managed endpoint.
+
+| Service | Description |
+|---------|-------------|
+| **[Chat](https://ibm.github.io/watsonx-ai-java-sdk/services/model-gateway/chat/)** | Synchronous and streaming chat completions to any configured model |
+| **[Catalog](https://ibm.github.io/watsonx-ai-java-sdk/services/model-gateway/catalog/)** | List all configured models and retrieve individual model details by UUID or alias |
+
+### Document Processing
+
+| Service | Description |
+|---------|-------------|
+| **[Schema](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/schema/)** | Create, improve, merge, and cluster document extraction schemas |
+| **[Text Extraction](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/text-extraction-service/)** | Structured data extraction from documents in IBM Cloud Object Storage |
+| **[Text Classification](https://ibm.github.io/watsonx-ai-java-sdk/services/document-processing/text-classification-service/)** | Document classification from IBM Cloud Object Storage |
+
+### Utilities
+
+| Service | Description |
+|---------|-------------|
+| **[Tool](https://ibm.github.io/watsonx-ai-java-sdk/services/tool-service/)** | Server-side utility tools for agentic workflows |
+| **[Tokenization](https://ibm.github.io/watsonx-ai-java-sdk/services/tokenization-service/)** | Token counting and analysis for any model |
+| **[Detection](https://ibm.github.io/watsonx-ai-java-sdk/services/detection-service/)** | Identification of harmful content (HAP), PII, and safety violations |
+| **[Foundation Model](https://ibm.github.io/watsonx-ai-java-sdk/services/foundation-model-service/)** | Browse and query the watsonx.ai model catalog |
 | **[File](https://ibm.github.io/watsonx-ai-java-sdk/services/file-service/)** | Upload, list, and retrieve files for use in batch processing jobs |
 | **[Batch](https://ibm.github.io/watsonx-ai-java-sdk/services/batch-service/)** | High-volume asynchronous inference from JSONL input files |
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -63,7 +63,15 @@ System.out.println(response.content());
 | **[Rerank](services/rerank-service)** | Score and sort a list of candidate passages against a query |
 | **[Time Series](services/time-series-service)** | Forecast time series data using IBM Granite TTM models |
 | **[Deployment](services/deployment-service)** | Target a deployed model by `deploymentId` for chat and forecasting |
-| **[Model Gateway](services/model-gateway)** | Chat with third-party models (OpenAI, Anthropic, etc.) via a unified IBM-managed gateway |
+
+### Model Gateway
+
+Proxy layer that routes requests to third-party foundation models (OpenAI, Anthropic, Azure, Mistral, and others) through a single IBM-managed endpoint.
+
+| Service | Description |
+|---------|-------------|
+| **[Chat](services/model-gateway/chat)** | Synchronous and streaming chat completions to any configured model |
+| **[Catalog](services/model-gateway/catalog)** | List and retrieve models configured in the gateway |
 
 ### Document processing
 

--- a/docs/content/migration/0.22.0-to-0.30.0.md
+++ b/docs/content/migration/0.22.0-to-0.30.0.md
@@ -241,3 +241,63 @@ Use `ChatClientContext<DeploymentChatRequest>` in a `DeploymentRestClient` and `
 ### New ModelGatewayService
 
 This release adds `ModelGatewayService` for sending chat requests to third-party models through the IBM watsonx.ai Model Gateway endpoint. It is a new, additive API with no migration required. See the [Model Gateway](../services/model-gateway/index.md) documentation for details.
+
+---
+
+### toAssistantMessage() and toAssistantMessages() now throw EmptyChatResponseException
+
+`ChatResponse.toAssistantMessage()` and `toAssistantMessages()` previously threw `IllegalStateException` when the response contained no usable output. They now throw `EmptyChatResponseException`, a dedicated runtime exception that carries the `FinishReason` of the empty choice, its zero-based `index`, and the original `ChatResponse`.
+
+Callers that caught `IllegalStateException` to handle empty responses must be updated:
+
+**Before:**
+```java
+try {
+    AssistantMessage message = response.toAssistantMessage();
+} catch (IllegalStateException e) {
+    // handle empty response
+}
+```
+
+**After:**
+```java
+try {
+    AssistantMessage message = response.toAssistantMessage();
+} catch (EmptyChatResponseException e) {
+    FinishReason reason = e.finishReason(); // e.g. LENGTH, CONTENT_FILTER
+    int index = e.index();                  // -1 when no choices at all
+    ChatResponse original = e.response();
+}
+```
+
+Callers that did not catch `IllegalStateException` are unaffected at runtime, but should update import statements.
+
+---
+
+### AssistantMessage record gained a thinking field
+
+The `AssistantMessage` record gained a `thinking` component that carries the model's reasoning content. The canonical constructor now takes an additional `String thinking` argument between `content` and `name`:
+
+**Before:**
+```java
+new AssistantMessage("assistant", content, name, refusal, toolCalls);
+```
+
+**After:**
+```java
+new AssistantMessage("assistant", content, thinking, name, refusal, toolCalls);
+```
+
+Code that uses the static factory methods (`AssistantMessage.text()`, `AssistantMessage.tools()`) or constructs the record via `toAssistantMessage()` is unaffected. Only code calling the canonical 5- or 6-argument constructor directly needs to be updated.
+
+---
+
+### New ModelGatewayCatalogService
+
+This release adds `ModelGatewayCatalogService` for listing and fetching models configured in the IBM watsonx.ai Model Gateway. It is a new, additive API with no migration required. See the [Model Gateway Catalog](../services/model-gateway/catalog.md) documentation for details.
+
+---
+
+### New ClusterSchemaService
+
+This release adds `ClusterSchemaService` for grouping a set of document schemas into semantically similar clusters. It is a new, additive API with no migration required.

--- a/docs/content/services/model-gateway/catalog.md
+++ b/docs/content/services/model-gateway/catalog.md
@@ -1,0 +1,132 @@
+---
+id: catalog
+title: Catalog
+---
+
+# Model Gateway - Catalog
+
+The `ModelGatewayCatalogService` provides read-only access to the list of models configured in the **IBM watsonx.ai Model Gateway**.
+
+## Quick Start
+
+```java
+ModelGatewayCatalogService catalog = ModelGatewayCatalogService.builder()
+    .baseUrl(CloudRegion.DALLAS)
+    .apiKey(WATSONX_API_KEY)
+    .build();
+
+List<ModelGatewayModel> models = catalog.listModels();
+models.forEach(m -> System.out.println(m.id() + " (" + m.ownedBy() + ")"));
+// → gpt-4o (openai)
+// → claude-3-5-sonnet (anthropic)
+```
+
+---
+
+## Service Configuration
+
+### Basic Setup
+
+```java
+ModelGatewayCatalogService catalog = ModelGatewayCatalogService.builder()
+    .baseUrl(CloudRegion.DALLAS)
+    .apiKey(WATSONX_API_KEY)
+    .build();
+```
+
+### Builder Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `apiKey` | String | Conditional | API key for IBM Cloud authentication |
+| `authenticator` | Authenticator | Conditional | Custom authentication (alternative to `apiKey`) |
+| `baseUrl` | String / CloudRegion | Yes | watsonx.ai ML endpoint |
+| `timeout` | Duration | No | Request timeout (default: 60 seconds) |
+| `logRequests` | Boolean | No | Enable request logging (default: false) |
+| `logResponses` | Boolean | No | Enable response logging (default: false) |
+| `httpClient` | HttpClient | No | Custom HTTP client |
+| `verifySsl` | Boolean | No | SSL certificate verification (default: true) |
+| `version` | String | No | API version override |
+
+> Either `apiKey` or `authenticator` must be provided.
+
+---
+
+## Operations
+
+### listModels
+
+Returns all models configured across all providers in the gateway.
+
+```java
+List<ModelGatewayModel> models = catalog.listModels();
+
+for (ModelGatewayModel model : models) {
+    System.out.println("UUID:     " + model.uuid());
+    System.out.println("ID:       " + model.id());
+    System.out.println("Alias:    " + model.optionalAlias().orElse("(none)"));
+    System.out.println("Provider: " + model.ownedBy());
+    System.out.println();
+}
+```
+
+### getModel
+
+Retrieves a single model by its **UUID or alias**. Both are accepted identifiers.
+
+```java
+// By alias
+ModelGatewayModel model = catalog.getModel("gpt-4o");
+
+// By UUID
+ModelGatewayModel model = catalog.getModel("123e4567-e89b-12d3-a456-426614174000");
+
+System.out.println("ID:       " + model.id());
+System.out.println("Provider: " + model.ownedBy());
+System.out.println("Created:  " + model.created());
+model.optionalMetadata().ifPresent(meta -> {
+    System.out.println("Family:   " + meta.modelFamily());
+    System.out.println("Region:   " + meta.region());
+    System.out.println("Cost/1k:  " + meta.cost());
+});
+```
+
+---
+
+## ModelGatewayModel
+
+Each model returned by the catalog exposes the following fields.
+
+### Core Fields
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `uuid()` | String | Unique identifier assigned by the gateway |
+| `object()` | String | Always `"model"` |
+| `created()` | Long | Unix timestamp (seconds) when this configuration was created |
+| `ownedBy()` | String | Provider in the format `<type>:<name>` (e.g., `"openai:my-provider"`) |
+| `id()` | String | Official provider-side model identifier (e.g., `"gpt-4o-2024-11-20"`) |
+| `alias()` | String | Optional friendly name - use this with `getModel()` instead of the full id |
+| `description()` | String | Optional user-defined description |
+| `metadata()` | ModelGatewayModel.Metadata | Optional additional configuration - may be `null` |
+
+### ModelGatewayModel.Metadata
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `cost()` | Double | Cost per 1 000 tokens in USD |
+| `modelFamily()` | String | Model series (e.g., `"gpt-4"`, `"claude-3"`) |
+| `recommenderLabel()` | String | Label used by the Recommender API |
+| `region()` | String | Deployment region (e.g., `"us-east-1"`) |
+| `batch()` | Boolean | Whether the model is preferred for batch requests |
+| `contextWindow()` | Integer | Maximum tokens the model can process in a single request |
+
+All `Metadata` fields may be `null` when not set by the administrator.
+
+---
+
+## Related Resources
+
+- [IBM watsonx.ai Model Gateway](https://www.ibm.com/docs/en/watsonx/w-and-w/2.4.x?topic=models-model-gateway)
+- [Managing the Model Gateway](https://www.ibm.com/docs/en/watsonx/w-and-w/2.4.x?topic=gateway-managing-model)
+- [Model Gateway Chat Documentation](./chat)

--- a/docs/content/services/model-gateway/index.md
+++ b/docs/content/services/model-gateway/index.md
@@ -65,6 +65,8 @@ The table below lists the Model Gateway operations available in this SDK.
 | Operation | Class | Status | Page |
 |-----------|-------|--------|------|
 | Chat completions | `ModelGatewayService` | Available | [Chat](./chat/) |
+| List models | `ModelGatewayCatalogService` | Available | [Catalog](./catalog/) |
+| Get model | `ModelGatewayCatalogService` | Available | [Catalog](./catalog/) |
 | Embeddings | - | Not yet implemented | - |
 | Audio transcription | - | Not yet implemented | - |
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -60,7 +60,8 @@ const sidebars: SidebarsConfig = {
           link: { type: 'doc', id: 'services/model-gateway/index' },
           collapsed: true,
           items: [
-            { type: 'doc', id: 'services/model-gateway/chat', label: 'Chat' },
+            { type: 'doc', id: 'services/model-gateway/chat',    label: 'Chat' },
+            { type: 'doc', id: 'services/model-gateway/catalog', label: 'Catalog' },
           ],
         },
         { type: 'doc', id: 'services/file-service',  label: 'File Service' },
@@ -83,7 +84,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Migration Guide',
       link: { type: 'doc', id: 'migration/migration' },
-      collapsed: false,
+      collapsed: true,
       items: [
         { type: 'doc', id: 'migration/0.22.0-to-0.30.0', label: '0.22.0 → 0.30.0' },
       ],

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxJacksonModule.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxJacksonModule.java
@@ -45,9 +45,11 @@ import com.ibm.watsonx.ai.detection.detector.GraniteGuardian;
 import com.ibm.watsonx.ai.detection.detector.Hap;
 import com.ibm.watsonx.ai.detection.detector.Pii;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModel;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters;
-import com.ibm.watsonx.ai.gateway.ModelGatewayTextChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayListModelsResponse;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayModel;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayTextChatRequest;
 import com.ibm.watsonx.ai.textgeneration.Moderation;
 import com.ibm.watsonx.ai.textgeneration.Moderation.InputRanges;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationParameters;
@@ -106,6 +108,9 @@ public class WatsonxJacksonModule extends SimpleModule {
         setMixInAnnotation(ModelGatewayParameters.StreamOptions.class, ModelGatewayStreamOptionsMixin.class);
         setMixInAnnotation(ModelGatewayParameters.Cache.class, ModelGatewayCacheMixin.class);
         setMixInAnnotation(ModelGatewayParameters.Router.class, ModelGatewayRouterMixin.class);
+        setMixInAnnotation(ModelGatewayModel.class, ModelGatewayModelMixin.class);
+        setMixInAnnotation(ModelGatewayModel.Metadata.class, ModelGatewayModelMetadataMixin.class);
+        setMixInAnnotation(ModelGatewayListModelsResponse.class, ModelGatewayListModelsResponseMixin.class);
 
         // --- Schema Mixin --- //
         setMixInAnnotation(ArraySchema.class, ArraySchemaMixin.class);
@@ -942,5 +947,36 @@ public class WatsonxJacksonModule extends SimpleModule {
         @JsonCreator
         public ModelGatewayRouterMixin(
             @JsonProperty("cache") ModelGatewayParameters.Cache cache) {}
+    }
+
+    public abstract static class ModelGatewayModelMixin {
+        @JsonCreator
+        public ModelGatewayModelMixin(
+            @JsonProperty("uuid") String uuid,
+            @JsonProperty("object") String object,
+            @JsonProperty("created") Long created,
+            @JsonProperty("owned_by") String ownedBy,
+            @JsonProperty("id") String id,
+            @JsonProperty("alias") String alias,
+            @JsonProperty("description") String description,
+            @JsonProperty("metadata") ModelGatewayModel.Metadata metadata) {}
+    }
+
+    public abstract static class ModelGatewayModelMetadataMixin {
+        @JsonCreator
+        public ModelGatewayModelMetadataMixin(
+            @JsonProperty("cost") Double cost,
+            @JsonProperty("model_family") String modelFamily,
+            @JsonProperty("recommender_label") String recommenderLabel,
+            @JsonProperty("region") String region,
+            @JsonProperty("batch") Boolean batch,
+            @JsonProperty("context_window") Integer contextWindow) {}
+    }
+
+    public abstract static class ModelGatewayListModelsResponseMixin {
+        @JsonCreator
+        public ModelGatewayListModelsResponseMixin(
+            @JsonProperty("object") String object,
+            @JsonProperty("data") List<ModelGatewayModel> data) {}
     }
 }

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/WatsonxService.java
@@ -20,7 +20,8 @@ import com.ibm.watsonx.ai.detection.DetectionService;
 import com.ibm.watsonx.ai.embedding.EmbeddingService;
 import com.ibm.watsonx.ai.file.FileService;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
-import com.ibm.watsonx.ai.gateway.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 import com.ibm.watsonx.ai.rerank.RerankService;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationService;
 import com.ibm.watsonx.ai.textprocessing.schema.create.CreateSchemaService;
@@ -55,6 +56,7 @@ import com.ibm.watsonx.ai.tool.ToolService;
  * @see CreateSchemaService
  * @see ImproveSchemaService
  * @see MergeSchemaService
+ * @see ModelGatewayCatalogService
  * @see ModelGatewayService
  */
 public abstract class WatsonxService {

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/BaseChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/BaseChatRequest.java
@@ -15,7 +15,7 @@ import com.ibm.watsonx.ai.chat.model.BaseChatParameters;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.deployment.DeploymentChatRequest;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
 
 /**
  * Abstract base holding the chat request fields shared by every {@link ChatProvider}.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatProvider.java
@@ -6,7 +6,7 @@ package com.ibm.watsonx.ai.chat;
 
 import java.util.concurrent.CompletableFuture;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
-import com.ibm.watsonx.ai.gateway.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 
 /**
  * Interface representing a provider capable of executing chat interactions with language models.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/ChatResponse.java
@@ -14,7 +14,7 @@ import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.FinishReason;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
 
 /**
  * Represents the response from a chat completion request.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/SseEventProcessor.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/SseEventProcessor.java
@@ -35,7 +35,7 @@ import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.streaming.StreamingStateTracker;
 import com.ibm.watsonx.ai.chat.streaming.StreamingToolFetcher;
 import com.ibm.watsonx.ai.core.Json;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
 
 /**
  * Processes Server-Sent Events.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/BaseChatParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/chat/model/BaseChatParameters.java
@@ -9,7 +9,7 @@ import static java.util.Objects.nonNull;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters;
 
 /**
  * Abstract base class that holds every chat parameter shared between the Text Chat API and the Model Gateway endpoint.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/DefaultRestClient.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/DefaultRestClient.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.gateway.catalog;
+
+import static com.ibm.watsonx.ai.core.Json.fromJson;
+import static java.util.Objects.requireNonNull;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import com.ibm.watsonx.ai.core.factory.HttpClientFactory;
+import com.ibm.watsonx.ai.core.http.SyncHttpClient;
+import com.ibm.watsonx.ai.core.http.interceptors.LoggerInterceptor.LogMode;
+
+/**
+ * Default implementation of the {@link ModelGatewayCatalogRestClient} abstract class.
+ */
+final class DefaultRestClient extends ModelGatewayCatalogRestClient {
+
+    private final SyncHttpClient syncHttpClient;
+
+    DefaultRestClient(Builder builder) {
+        super(builder);
+        syncHttpClient = HttpClientFactory.createSync(authenticator, httpClient, LogMode.of(logRequests, logResponses));
+    }
+
+    @Override
+    public List<ModelGatewayModel> listModels() {
+        var url = URI.create(baseUrl + "/ml/gateway/v1/models?version=%s".formatted(version));
+        var httpRequest = HttpRequest.newBuilder(url)
+            .header("Accept", "application/json")
+            .GET()
+            .build();
+        try {
+            var httpResponse = syncHttpClient.send(httpRequest, BodyHandlers.ofString());
+            return fromJson(httpResponse.body(), ModelGatewayListModelsResponse.class).data();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ModelGatewayModel getModel(String modelUuid) {
+        requireNonNull(modelUuid, "modelUuid cannot be null");
+        var url = URI.create(baseUrl + "/ml/gateway/v1/models/%s?version=%s".formatted(modelUuid, version));
+        var httpRequest = HttpRequest.newBuilder(url)
+            .header("Accept", "application/json")
+            .GET()
+            .build();
+        try {
+            var httpResponse = syncHttpClient.send(httpRequest, BodyHandlers.ofString());
+            return fromJson(httpResponse.body(), ModelGatewayModel.class);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link DefaultRestClient} instances with configurable parameters.
+     */
+    public static final class Builder extends ModelGatewayCatalogRestClient.Builder {
+
+        private Builder() {}
+
+        /**
+         * Builds a {@link DefaultRestClient} instance using the configured parameters.
+         *
+         * @return a new instance of {@link DefaultRestClient}
+         */
+        public DefaultRestClient build() {
+            return new DefaultRestClient(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayCatalogRestClient.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayCatalogRestClient.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.gateway.catalog;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+import com.ibm.watsonx.ai.WatsonxRestClient;
+
+/**
+ * Abstraction of a REST client for interacting with the IBM watsonx.ai Model Gateway catalog APIs.
+ */
+public abstract class ModelGatewayCatalogRestClient extends WatsonxRestClient {
+
+    protected ModelGatewayCatalogRestClient(Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Lists all configured model details aggregated across all configured providers.
+     *
+     * @return a list of {@link ModelGatewayModel} instances
+     */
+    public abstract List<ModelGatewayModel> listModels();
+
+    /**
+     * Retrieves a specific model configuration by UUID or alias.
+     *
+     * @param modelId the UUID or alias of the model to retrieve
+     * @return the {@link ModelGatewayModel} matching the given identifier
+     */
+    public abstract ModelGatewayModel getModel(String modelId);
+
+    /**
+     * Creates a new {@link Builder} using the first available {@link ModelGatewayCatalogRestClientBuilderFactory} discovered via
+     * {@link ServiceLoader}.
+     * <p>
+     * If no factory is found, falls back to the default {@link DefaultRestClient}.
+     */
+    static ModelGatewayCatalogRestClient.Builder builder() {
+        return ServiceLoader.load(ModelGatewayCatalogRestClientBuilderFactory.class).findFirst()
+            .map(Supplier::get)
+            .orElse(DefaultRestClient.builder());
+    }
+
+    /**
+     * Builder abstract class for constructing {@link ModelGatewayCatalogRestClient} instances with configurable parameters.
+     */
+    public abstract static class Builder extends WatsonxRestClient.Builder<ModelGatewayCatalogRestClient, Builder> {}
+
+    /**
+     * Service Provider Interface for supplying custom {@link Builder} implementations.
+     * <p>
+     * This allows frameworks to provide their own client implementations.
+     */
+    public interface ModelGatewayCatalogRestClientBuilderFactory extends Supplier<ModelGatewayCatalogRestClient.Builder> {}
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayCatalogService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayCatalogService.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.gateway.catalog;
+
+import static java.util.Objects.requireNonNull;
+import java.util.List;
+import com.ibm.watsonx.ai.WatsonxService;
+import com.ibm.watsonx.ai.core.auth.Authenticator;
+
+/**
+ * Service for interacting with the IBM watsonx.ai Model Gateway catalog APIs.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ModelGatewayCatalogService catalogService = ModelGatewayCatalogService.builder()
+ *     .baseUrl("https://...")  // or use CloudRegion
+ *     .apiKey("my-api-key")    // creates an IBM Cloud Authenticator
+ *     .build();
+ *
+ * List<ModelGatewayModel> models = catalogService.listModels();
+ * ModelGatewayModel model = catalogService.getModel("gpt-4o");  // alias or UUID
+ * }</pre>
+ *
+ * To use a custom authentication mechanism, configure it explicitly with {@code authenticator(Authenticator)}.
+ *
+ * @see Authenticator
+ */
+public class ModelGatewayCatalogService extends WatsonxService {
+
+    private final ModelGatewayCatalogRestClient client;
+
+    private ModelGatewayCatalogService(Builder builder) {
+        super(builder);
+        requireNonNull(builder.authenticator(), "authenticator cannot be null");
+        client = ModelGatewayCatalogRestClient.builder()
+            .baseUrl(baseUrl)
+            .version(version)
+            .logRequests(logRequests)
+            .logResponses(logResponses)
+            .timeout(timeout)
+            .authenticator(builder.authenticator())
+            .httpClient(httpClient)
+            .verifySsl(verifySsl)
+            .build();
+    }
+
+    /**
+     * Lists all configured model details aggregated across all configured providers.
+     *
+     * @return a list of {@link ModelGatewayModel} instances
+     */
+    public List<ModelGatewayModel> listModels() {
+        return client.listModels();
+    }
+
+    /**
+     * Retrieves a specific model configuration by UUID or alias.
+     *
+     * @param modelId the UUID or alias of the model to retrieve
+     * @return the {@link ModelGatewayModel} matching the given identifier
+     */
+    public ModelGatewayModel getModel(String modelId) {
+        return client.getModel(modelId);
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     *
+     * @return a new {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link ModelGatewayCatalogService} instances with configurable parameters.
+     */
+    public static final class Builder extends WatsonxService.Builder<Builder> {
+
+        private Builder() {}
+
+        /**
+         * Builds a {@link ModelGatewayCatalogService} instance using the configured parameters.
+         *
+         * @return a new instance of {@link ModelGatewayCatalogService}
+         */
+        public ModelGatewayCatalogService build() {
+            return new ModelGatewayCatalogService(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayListModelsResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayListModelsResponse.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.gateway.catalog;
+
+import java.util.List;
+
+/**
+ * Response returned by the list-models endpoint of the IBM watsonx.ai Model Gateway.
+ *
+ * @param object the object type, always {@code "list"}
+ * @param data the list of models
+ */
+public record ModelGatewayListModelsResponse(String object, List<ModelGatewayModel> data) {}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayModel.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayModel.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.gateway.catalog;
+
+/**
+ * Represents a model configuration returned by the IBM watsonx.ai Model Gateway.
+ *
+ * @param uuid the unique identifier for the model
+ * @param object the object type, always {@code "model"}
+ * @param created the Unix timestamp (in seconds) when the model configuration was created
+ * @param ownedBy the provider that owns the model, in the format {@code "<provider_type>:<provider_name>"}
+ * @param id the official provider-specific server-side unique identifier of the model instance
+ * @param alias an optional friendly name for the model
+ * @param description a custom user-defined description for the model
+ * @param metadata additional configuration for the model
+ */
+public record ModelGatewayModel(
+    String uuid,
+    String object,
+    Long created,
+    String ownedBy,
+    String id,
+    String alias,
+    String description,
+    Metadata metadata) {
+
+    /**
+     * Additional configuration for a model.
+     *
+     * @param cost the cost per 1000 tokens for the model, in USD
+     * @param modelFamily the family or series this model belongs to
+     * @param recommenderLabel the label used by the Recommender API to map to supported models
+     * @param region the region where this model is deployed
+     * @param batch whether the model is eligible or preferred for batch requests
+     * @param contextWindow the maximum number of tokens the model can process in a single request
+     */
+    public record Metadata(
+        Double cost,
+        String modelFamily,
+        String recommenderLabel,
+        String region,
+        Boolean batch,
+        Integer contextWindow) {}
+}

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/DefaultRestClient.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/DefaultRestClient.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static com.ibm.watsonx.ai.core.Json.fromJson;
 import static com.ibm.watsonx.ai.core.Json.toJson;

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayChatRequest.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import com.ibm.watsonx.ai.chat.BaseChatRequest;
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayChatResponse.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayChatResponse.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayParameters.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayParameters.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayRestClient.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayRestClient.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import java.time.Duration;
 import java.util.ServiceLoader;

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayService.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayService.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayTextChatRequest.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayTextChatRequest.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static java.util.Objects.isNull;
 import java.util.Collections;
@@ -12,9 +12,9 @@ import java.util.Map;
 import com.ibm.watsonx.ai.chat.model.BaseChatParameters.JsonSchemaObject;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.Prediction;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.StreamOptions;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Prediction;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.StreamOptions;
 
 /**
  * Payload request for the Model Gateway chat completions endpoint.

--- a/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayUtility.java
+++ b/modules/watsonx-ai/src/main/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayUtility.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static com.ibm.watsonx.ai.core.Utils.getOrDefault;
 import static java.util.Objects.isNull;
@@ -10,7 +10,7 @@ import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNullElse;
 import java.util.Map;
 import com.ibm.watsonx.ai.chat.model.BaseChatParameters;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.StreamOptions;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.StreamOptions;
 
 /**
  * Utility class for building {@link ModelGatewayTextChatRequest} wire payloads from a {@link ModelGatewayChatRequest} and default

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/ContextDepedencyInjectionTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/ContextDepedencyInjectionTest.java
@@ -16,7 +16,7 @@ import com.ibm.watsonx.ai.detection.DetectionService;
 import com.ibm.watsonx.ai.embedding.EmbeddingService;
 import com.ibm.watsonx.ai.file.FileService;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
-import com.ibm.watsonx.ai.gateway.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 import com.ibm.watsonx.ai.rerank.RerankService;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationService;
 import com.ibm.watsonx.ai.textprocessing.schema.create.CreateSchemaService;

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/CustomHttpClientTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/CustomHttpClientTest.java
@@ -21,7 +21,7 @@ import com.ibm.watsonx.ai.detection.DetectionService;
 import com.ibm.watsonx.ai.embedding.EmbeddingService;
 import com.ibm.watsonx.ai.file.FileService;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
-import com.ibm.watsonx.ai.gateway.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 import com.ibm.watsonx.ai.rerank.RerankService;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationService;
 import com.ibm.watsonx.ai.textprocessing.schema.create.CreateSchemaService;

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ChatResponseTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/chat/ChatResponseTest.java
@@ -23,7 +23,7 @@ import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import com.ibm.watsonx.ai.chat.model.FinishReason;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
 
 public class ChatResponseTest {
 

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/client/CustomRestClientTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/client/CustomRestClientTest.java
@@ -24,6 +24,7 @@ import com.ibm.watsonx.ai.client.impl.CustomFoundationModelRestClient;
 import com.ibm.watsonx.ai.client.impl.CustomIBMCloudRestClient;
 import com.ibm.watsonx.ai.client.impl.CustomImproveSchemaRestClient;
 import com.ibm.watsonx.ai.client.impl.CustomMergeSchemaRestClient;
+import com.ibm.watsonx.ai.client.impl.CustomModelGatewayCatalogRestClient;
 import com.ibm.watsonx.ai.client.impl.CustomModelGatewayRestClient;
 import com.ibm.watsonx.ai.client.impl.CustomRerankRestClient;
 import com.ibm.watsonx.ai.client.impl.CustomTextClassificationRestClient;
@@ -41,7 +42,8 @@ import com.ibm.watsonx.ai.detection.DetectionService;
 import com.ibm.watsonx.ai.embedding.EmbeddingService;
 import com.ibm.watsonx.ai.file.FileService;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
-import com.ibm.watsonx.ai.gateway.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 import com.ibm.watsonx.ai.rerank.RerankService;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationService;
 import com.ibm.watsonx.ai.textprocessing.schema.create.CreateSchemaService;
@@ -183,6 +185,22 @@ public class CustomRestClientTest {
         clientField.setAccessible(true);
         var client = clientField.get(modelGatewayService);
         assertTrue(client instanceof CustomModelGatewayRestClient);
+    }
+
+    @Test
+    // com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogRestClient$ModelGatewayCatalogRestClientBuilderFactory
+    public void should_use_custom_rest_client_when_building_model_gateway_catalog_service() throws Exception {
+
+        ModelGatewayCatalogService catalogService = ModelGatewayCatalogService.builder()
+            .apiKey("test")
+            .baseUrl("http://localhost")
+            .build();
+
+        Class<ModelGatewayCatalogService> clazz = ModelGatewayCatalogService.class;
+        var clientField = clazz.getDeclaredField("client");
+        clientField.setAccessible(true);
+        var client = clientField.get(catalogService);
+        assertTrue(client instanceof CustomModelGatewayCatalogRestClient);
     }
 
     @Test

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/client/impl/CustomModelGatewayCatalogRestClient.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/client/impl/CustomModelGatewayCatalogRestClient.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.client.impl;
+
+import java.util.List;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogRestClient;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayModel;
+
+public class CustomModelGatewayCatalogRestClient extends ModelGatewayCatalogRestClient {
+
+    CustomModelGatewayCatalogRestClient(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public List<ModelGatewayModel> listModels() {
+        throw new UnsupportedOperationException("Unimplemented method 'listModels'");
+    }
+
+    @Override
+    public ModelGatewayModel getModel(String modelId) {
+        throw new UnsupportedOperationException("Unimplemented method 'getModel'");
+    }
+
+    public static final class CustomModelGatewayCatalogRestClientBuilderFactory
+        implements ModelGatewayCatalogRestClientBuilderFactory {
+        @Override
+        public Builder get() {
+            return new CustomModelGatewayCatalogRestClient.Builder();
+        }
+    }
+
+    static final class Builder extends ModelGatewayCatalogRestClient.Builder {
+        @Override
+        public ModelGatewayCatalogRestClient build() {
+            return new CustomModelGatewayCatalogRestClient(this);
+        }
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/client/impl/CustomModelGatewayRestClient.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/client/impl/CustomModelGatewayRestClient.java
@@ -9,10 +9,10 @@ import java.util.concurrent.CompletableFuture;
 import com.ibm.watsonx.ai.chat.ChatClientContext;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatRequest;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.ModelGatewayRestClient;
-import com.ibm.watsonx.ai.gateway.ModelGatewayTextChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayRestClient;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayTextChatRequest;
 
 public class CustomModelGatewayRestClient extends ModelGatewayRestClient {
 

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayCatalogServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/catalog/ModelGatewayCatalogServiceTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.gateway.catalog;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import com.ibm.watsonx.ai.AbstractWatsonxTest;
+
+public class ModelGatewayCatalogServiceTest extends AbstractWatsonxTest {
+
+    private ModelGatewayCatalogService buildService() {
+        return ModelGatewayCatalogService.builder()
+            .authenticator(mockAuthenticator)
+            .baseUrl(URI.create("http://localhost:%s".formatted(wireMock.getPort())))
+            .version(API_VERSION)
+            .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // listModels
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_list_models_and_parse_all_fields() {
+
+        wireMock.stubFor(get("/ml/gateway/v1/models?version=%s".formatted(API_VERSION))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("""
+                    {
+                        "object": "list",
+                        "data": [
+                            {
+                                "uuid": "123e4567-e89b-12d3-a456-426614174000",
+                                "object": "model",
+                                "created": 1677649963,
+                                "owned_by": "openai",
+                                "id": "gpt-4o",
+                                "alias": "gpt-4o-alias",
+                                "description": "A flagship model",
+                                "metadata": {
+                                    "cost": 0.02,
+                                    "model_family": "gpt-4",
+                                    "recommender_label": "gpt-4o",
+                                    "region": "us-east-1",
+                                    "batch": false,
+                                    "context_window": 128000
+                                }
+                            }
+                        ]
+                    }""")));
+
+        when(mockAuthenticator.token()).thenReturn("my-super-token");
+
+        var models = buildService().listModels();
+
+        assertNotNull(models);
+        assertEquals(1, models.size());
+        var m = models.get(0);
+        assertEquals("123e4567-e89b-12d3-a456-426614174000", m.uuid());
+        assertEquals("model", m.object());
+        assertEquals(1677649963L, m.created());
+        assertEquals("openai", m.ownedBy());
+        assertEquals("gpt-4o", m.id());
+        assertEquals("gpt-4o-alias", m.alias());
+        assertEquals("A flagship model", m.description());
+        assertNotNull(m.metadata());
+        assertEquals(0.02, m.metadata().cost());
+        assertEquals("gpt-4", m.metadata().modelFamily());
+        assertEquals("gpt-4o", m.metadata().recommenderLabel());
+        assertEquals("us-east-1", m.metadata().region());
+        assertEquals(false, m.metadata().batch());
+        assertEquals(128000, m.metadata().contextWindow());
+    }
+
+    @Test
+    void should_return_empty_list_when_no_models_configured() {
+
+        wireMock.stubFor(get("/ml/gateway/v1/models?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("""
+                    { "object": "list", "data": [] }""")));
+
+        when(mockAuthenticator.token()).thenReturn("my-super-token");
+
+        var models = buildService().listModels();
+
+        assertNotNull(models);
+        assertTrue(models.isEmpty());
+    }
+
+    @Test
+    void should_wrap_io_exception_from_list_models() {
+
+        withWatsonxServiceMock(() -> {
+
+            var service = ModelGatewayCatalogService.builder()
+                .authenticator(mockAuthenticator)
+                .baseUrl(URI.create("http://localhost"))
+                .version(API_VERSION)
+                .build();
+
+            when(mockAuthenticator.token()).thenReturn("my-super-token");
+            when(mockSecureHttpClient.sendAsync(any(), any()))
+                .thenThrow(new RuntimeException("connection refused"));
+
+            // listModels uses the sync client — simulate by building against a port with no listener
+            assertThrows(Exception.class, () -> service.listModels());
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // getModel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_get_model_by_uuid_and_parse_all_fields() {
+
+        var uuid = "123e4567-e89b-12d3-a456-426614174000";
+        wireMock.stubFor(get("/ml/gateway/v1/models/%s?version=%s".formatted(uuid, API_VERSION))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("""
+                    {
+                        "uuid": "123e4567-e89b-12d3-a456-426614174000",
+                        "object": "model",
+                        "created": 1677649963,
+                        "owned_by": "openai:vllm4",
+                        "id": "gpt-3.5-turbo-456723",
+                        "alias": "gpt-3.5-turbo",
+                        "description": "A fast and cheap model",
+                        "metadata": {
+                            "cost": 0.002,
+                            "model_family": "gpt-3.5",
+                            "recommender_label": "gpt-3.5-turbo",
+                            "region": "us-east-1",
+                            "batch": true,
+                            "context_window": 4096
+                        }
+                    }""")));
+
+        when(mockAuthenticator.token()).thenReturn("my-super-token");
+
+        var m = buildService().getModel(uuid);
+
+        assertNotNull(m);
+        assertEquals("123e4567-e89b-12d3-a456-426614174000", m.uuid());
+        assertEquals("model", m.object());
+        assertEquals(1677649963L, m.created());
+        assertEquals("openai:vllm4", m.ownedBy());
+        assertEquals("gpt-3.5-turbo-456723", m.id());
+        assertEquals("gpt-3.5-turbo", m.alias());
+        assertEquals("A fast and cheap model", m.description());
+        assertNotNull(m.metadata());
+        assertEquals(0.002, m.metadata().cost());
+        assertEquals("gpt-3.5", m.metadata().modelFamily());
+        assertEquals("gpt-3.5-turbo", m.metadata().recommenderLabel());
+        assertEquals("us-east-1", m.metadata().region());
+        assertEquals(true, m.metadata().batch());
+        assertEquals(4096, m.metadata().contextWindow());
+    }
+
+    @Test
+    void should_return_empty_optional_fields_when_absent() {
+
+        wireMock.stubFor(get("/ml/gateway/v1/models/minimal?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("""
+                    {
+                        "uuid": "minimal",
+                        "object": "model",
+                        "created": 1677649963,
+                        "owned_by": "openai",
+                        "id": "gpt-4o"
+                    }""")));
+
+        when(mockAuthenticator.token()).thenReturn("my-super-token");
+
+        var m = buildService().getModel("minimal");
+
+        assertNull(m.alias());
+        assertNull(m.description());
+        assertNull(m.metadata());
+    }
+
+    @Test
+    void should_return_present_optionals_when_fields_are_set() {
+
+        wireMock.stubFor(get("/ml/gateway/v1/models/full?version=%s".formatted(API_VERSION))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("""
+                    {
+                        "uuid": "full",
+                        "object": "model",
+                        "created": 1677649963,
+                        "owned_by": "openai",
+                        "id": "gpt-4o",
+                        "alias": "friendly-name",
+                        "description": "A useful model",
+                        "metadata": { "cost": 0.01 }
+                    }""")));
+
+        when(mockAuthenticator.token()).thenReturn("my-super-token");
+
+        var m = buildService().getModel("full");
+
+        assertNotNull(m.alias());
+        assertEquals("friendly-name", m.alias());
+        assertNotNull(m.description());
+        assertEquals("A useful model", m.description());
+        assertNotNull(m.metadata());
+        assertEquals(0.01, m.metadata().cost());
+    }
+
+    @Test
+    void should_throw_npe_when_uuid_is_null() {
+
+        withWatsonxServiceMock(() -> {
+
+            var service = ModelGatewayCatalogService.builder()
+                .authenticator(mockAuthenticator)
+                .baseUrl(URI.create("http://localhost"))
+                .version(API_VERSION)
+                .build();
+
+            assertThrows(NullPointerException.class, () -> service.getModel(null));
+        });
+    }
+
+    @Test
+    void should_wrap_io_exception_from_get_model() {
+
+        withWatsonxServiceMock(() -> {
+
+            var service = ModelGatewayCatalogService.builder()
+                .authenticator(mockAuthenticator)
+                .baseUrl(URI.create("http://localhost"))
+                .version(API_VERSION)
+                .build();
+
+            when(mockAuthenticator.token()).thenReturn("my-super-token");
+            when(mockSecureHttpClient.sendAsync(any(), any()))
+                .thenThrow(new RuntimeException("connection refused"));
+
+            // getModel uses the sync client — simulate by building against a port with no listener
+            assertThrows(Exception.class, () -> service.getModel("some-uuid"));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_throw_when_authenticator_is_missing() {
+
+        var ex = assertThrows(NullPointerException.class, () -> ModelGatewayCatalogService.builder()
+            .baseUrl(URI.create("http://localhost"))
+            .build());
+        assertEquals("authenticator cannot be null", ex.getMessage());
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayChatRequestTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayChatRequestTest.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayParametersTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayParametersTest.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -12,12 +12,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.Cache;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.Prediction;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ServiceTier;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.StreamOptions;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Prediction;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.StreamOptions;
 
 @SuppressWarnings("deprecation")
 public class ModelGatewayParametersTest {

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayServiceTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayServiceTest.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -49,7 +49,7 @@ import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.chat.model.schema.JsonSchema;
 import com.ibm.watsonx.ai.core.exception.WatsonxException;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.StreamOptions;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.StreamOptions;
 
 @SuppressWarnings("unchecked")
 public class ModelGatewayServiceTest extends AbstractWatsonxTest {
@@ -913,4 +913,5 @@ public class ModelGatewayServiceTest extends AbstractWatsonxTest {
         var response = assertInstanceOf(ModelGatewayChatResponse.class, assertDoesNotThrow(() -> result.get(5, TimeUnit.SECONDS)));
         assertEquals("Logged", response.choices().get(0).message().content());
     }
+
 }

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayUtilityTest.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/gateway/chat/ModelGatewayUtilityTest.java
@@ -2,7 +2,7 @@
  * Copyright 2025 IBM Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.ibm.watsonx.ai.gateway;
+package com.ibm.watsonx.ai.gateway.chat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ClusterSchemaServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ClusterSchemaServiceIT.java
@@ -25,7 +25,7 @@ import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemas;
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
-public class ClusterSchemaIT {
+public class ClusterSchemaServiceIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
@@ -104,7 +104,7 @@ public class ClusterSchemaIT {
 
         // Poll until complete using fetchRequest
         String id = response.metadata().id();
-        ClusterSchemaIT.waitUntilComplete(id);
+        ClusterSchemaServiceIT.waitUntilComplete(id);
 
         var completed = clusterSchemaService.fetchRequest(id);
         assertNotNull(completed.entity().results().schemas());

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/CreateSchemaServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/CreateSchemaServiceIT.java
@@ -36,7 +36,7 @@ import com.ibm.watsonx.ai.textprocessing.textextraction.TextExtractionService;
 @EnabledIfEnvironmentVariable(named = "WATSONX_DOCUMENT_REFERENCE_BUCKET", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "CLOUD_OBJECT_STORAGE_URL", matches = ".+")
 @ResourceLock("watsonx-cos-document-bucket")
-public class CreateSchemaIT {
+public class CreateSchemaServiceIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String COS_API_KEY = System.getenv("CLOUD_OBJECT_STORAGE_API_KEY");

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ImproveSchemaServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ImproveSchemaServiceIT.java
@@ -22,7 +22,7 @@ import com.ibm.watsonx.ai.textprocessing.schema.improve.ImproveSchemaService;
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
-public class ImproveSchemaIT {
+public class ImproveSchemaServiceIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/MergeSchemaServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/MergeSchemaServiceIT.java
@@ -24,7 +24,7 @@ import com.ibm.watsonx.ai.textprocessing.schema.merge.MergeSchemaService;
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
-public class MergeSchemaIT {
+public class MergeSchemaServiceIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ModelGatewayCatalogServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ModelGatewayCatalogServiceIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.watsonx.ai.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogService;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class ModelGatewayCatalogServiceIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
+    static final String URL = System.getenv("WATSONX_URL");
+
+    @Test
+    void should_return_model_list() {
+
+        var modelGatewayCatalogService = ModelGatewayCatalogService.builder()
+            .apiKey(API_KEY)
+            .baseUrl(URL)
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+        var models = modelGatewayCatalogService.listModels();
+        assertTrue(models.size() > 0);
+        assertNull(models.get(0).alias());
+        assertNotNull(models.get(0).created());
+        assertNull(models.get(0).description());
+        assertNotNull(models.get(0).id());
+        assertNotNull(models.get(0).uuid());
+        assertNotNull(models.get(0).object());
+        assertNotNull(models.get(0).ownedBy());
+        assertNull(models.get(0).metadata());
+    }
+
+    @Test
+    void should_return_model_by_id() {
+
+        var modelGatewayCatalogService = ModelGatewayCatalogService.builder()
+            .apiKey(API_KEY)
+            .baseUrl(URL)
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+        var models = modelGatewayCatalogService.listModels();
+        assertTrue(models.size() > 0);
+
+        var model = modelGatewayCatalogService.getModel(models.get(0).uuid());
+        assertEquals(models.get(0).alias(), model.alias());
+        assertEquals(models.get(0).created(), model.created());
+        assertEquals(models.get(0).description(), model.description());
+        assertEquals(models.get(0).id(), model.id());
+        assertEquals(models.get(0).metadata(), model.metadata());
+        assertEquals(models.get(0).object(), model.object());
+        assertEquals(models.get(0).ownedBy(), model.ownedBy());
+        assertEquals(models.get(0).uuid(), model.uuid());
+    }
+}

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ModelGatewayServiceIT.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/it/ModelGatewayServiceIT.java
@@ -54,14 +54,14 @@ import com.ibm.watsonx.ai.chat.model.schema.JsonSchema;
 import com.ibm.watsonx.ai.core.auth.Authenticator;
 import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
 import com.ibm.watsonx.ai.core.exception.WatsonxException;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatRequest;
-import com.ibm.watsonx.ai.gateway.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters;
-import com.ibm.watsonx.ai.gateway.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
-public class ModelGatewayIT {
+public class ModelGatewayServiceIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
     static final String URL = System.getenv("WATSONX_URL");

--- a/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/utils/ServiceLoaderUtils.java
+++ b/modules/watsonx-ai/src/test/java/com/ibm/watsonx/ai/utils/ServiceLoaderUtils.java
@@ -47,7 +47,7 @@ public class ServiceLoaderUtils {
             "com.ibm.watsonx.ai.client.impl.CustomDeploymentRestClient$CustomDeploymentRestClientBuilderFactory");
 
         createServiceFile(metaInfServices,
-            "com.ibm.watsonx.ai.gateway.ModelGatewayRestClient$ModelGatewayRestClientBuilderFactory",
+            "com.ibm.watsonx.ai.gateway.chat.ModelGatewayRestClient$ModelGatewayRestClientBuilderFactory",
             "com.ibm.watsonx.ai.client.impl.CustomModelGatewayRestClient$CustomModelGatewayRestClientBuilderFactory");
 
         createServiceFile(metaInfServices,
@@ -109,6 +109,10 @@ public class ServiceLoaderUtils {
         createServiceFile(metaInfServices,
             "com.ibm.watsonx.ai.batch.BatchRestClient$BatchRestClientBuilderFactory",
             "com.ibm.watsonx.ai.client.impl.CustomBatchRestClient$CustomBatchRestClientBuilderFactory");
+
+        createServiceFile(metaInfServices,
+            "com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogRestClient$ModelGatewayCatalogRestClientBuilderFactory",
+            "com.ibm.watsonx.ai.client.impl.CustomModelGatewayCatalogRestClient$CustomModelGatewayCatalogRestClientBuilderFactory");
 
         URLClassLoader tempClassLoader = new URLClassLoader(
             new URL[] { tempDir.toUri().toURL() },


### PR DESCRIPTION
Adds `ModelGatewayCatalogService`, a new read-only service that lists and retrieves models configured in the IBM watsonx.ai Model Gateway catalog.